### PR TITLE
fix(tui): pass directory parameter to all API calls

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -72,7 +72,7 @@ export const TuiCommand = cmd({
       }),
   handler: async (args) => {
     while (true) {
-      const cwd = args.project ? path.resolve(args.project) : process.cwd()
+      const cwd = args.project ? path.resolve(args.project) : process.env["OPENCODE_ORIGINAL_CWD"] || process.cwd()
       try {
         process.chdir(cwd)
       } catch (e) {

--- a/packages/tui/cmd/opencode/main.go
+++ b/packages/tui/cmd/opencode/main.go
@@ -72,7 +72,14 @@ func main() {
 	batch := errgroup.Group{}
 
 	batch.Go(func() error {
-		result, err := httpClient.Project.Current(context.Background(), opencode.ProjectCurrentParams{})
+		// Use OPENCODE_ORIGINAL_CWD from environment if available (set by wrapper script)
+		wd := os.Getenv("OPENCODE_ORIGINAL_CWD")
+		if wd == "" {
+			wd, _ = os.Getwd()
+		}
+		result, err := httpClient.Project.Current(context.Background(), opencode.ProjectCurrentParams{
+			Directory: opencode.F(wd),
+		})
 		if err != nil {
 			return err
 		}
@@ -81,7 +88,14 @@ func main() {
 	})
 
 	batch.Go(func() error {
-		result, err := httpClient.Agent.List(context.Background(), opencode.AgentListParams{})
+		// Use OPENCODE_ORIGINAL_CWD from environment if available (set by wrapper script)
+		wd := os.Getenv("OPENCODE_ORIGINAL_CWD")
+		if wd == "" {
+			wd, _ = os.Getwd()
+		}
+		result, err := httpClient.Agent.List(context.Background(), opencode.AgentListParams{
+			Directory: opencode.F(wd),
+		})
 		if err != nil {
 			return err
 		}
@@ -90,7 +104,14 @@ func main() {
 	})
 
 	batch.Go(func() error {
-		result, err := httpClient.Path.Get(context.Background(), opencode.PathGetParams{})
+		// Use OPENCODE_ORIGINAL_CWD from environment if available (set by wrapper script)
+		wd := os.Getenv("OPENCODE_ORIGINAL_CWD")
+		if wd == "" {
+			wd, _ = os.Getwd()
+		}
+		result, err := httpClient.Path.Get(context.Background(), opencode.PathGetParams{
+			Directory: opencode.F(wd),
+		})
 		if err != nil {
 			return err
 		}
@@ -136,7 +157,9 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
 	go func() {
-		stream := httpClient.Event.ListStreaming(ctx, opencode.EventListParams{})
+		stream := httpClient.Event.ListStreaming(ctx, opencode.EventListParams{
+			Directory: opencode.F(project.Worktree),
+		})
 		for stream.Next() {
 			evt := stream.Current().AsUnion()
 			program.Send(evt)

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -112,9 +112,16 @@ func New(
 	initialSession *string,
 ) (*App, error) {
 	util.RootPath = project.Worktree
-	util.CwdPath, _ = os.Getwd()
+	// Use OPENCODE_ORIGINAL_CWD from environment if available (set by wrapper script)
+	if originalCwd := os.Getenv("OPENCODE_ORIGINAL_CWD"); originalCwd != "" {
+		util.CwdPath = originalCwd
+	} else {
+		util.CwdPath, _ = os.Getwd()
+	}
 
-	configInfo, err := httpClient.Config.Get(ctx, opencode.ConfigGetParams{})
+	configInfo, err := httpClient.Config.Get(ctx, opencode.ConfigGetParams{
+		Directory: opencode.F(project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +196,9 @@ func New(
 
 	slog.Debug("Loaded config", "config", configInfo)
 
-	customCommands, err := httpClient.Command.List(ctx, opencode.CommandListParams{})
+	customCommands, err := httpClient.Command.List(ctx, opencode.CommandListParams{
+		Directory: opencode.F(project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +470,9 @@ func findProviderByID(providers []opencode.Provider, providerID string) *opencod
 }
 
 func (a *App) InitializeProvider() tea.Cmd {
-	providersResponse, err := a.Client.App.Providers(context.Background(), opencode.AppProvidersParams{})
+	providersResponse, err := a.Client.App.Providers(context.Background(), opencode.AppProvidersParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		slog.Error("Failed to list providers", "error", err)
 		// TODO: notify user
@@ -717,6 +728,7 @@ func (a *App) InitializeProject(ctx context.Context) tea.Cmd {
 
 	go func() {
 		_, err := a.Client.Session.Init(ctx, a.Session.ID, opencode.SessionInitParams{
+			Directory:  opencode.F(a.Project.Worktree),
 			MessageID:  opencode.F(id.Ascending(id.Message)),
 			ProviderID: opencode.F(a.Provider.ID),
 			ModelID:    opencode.F(a.Model.ID),
@@ -747,6 +759,7 @@ func (a *App) CompactSession(ctx context.Context) tea.Cmd {
 			compactCtx,
 			a.Session.ID,
 			opencode.SessionSummarizeParams{
+				Directory:  opencode.F(a.Project.Worktree),
 				ProviderID: opencode.F(a.Provider.ID),
 				ModelID:    opencode.F(a.Model.ID),
 			},
@@ -773,7 +786,9 @@ func (a *App) MarkProjectInitialized(ctx context.Context) error {
 }
 
 func (a *App) CreateSession(ctx context.Context) (*opencode.Session, error) {
-	session, err := a.Client.Session.New(ctx, opencode.SessionNewParams{})
+	session, err := a.Client.Session.New(ctx, opencode.SessionNewParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -798,6 +813,7 @@ func (a *App) SendPrompt(ctx context.Context, prompt Prompt) (*App, tea.Cmd) {
 
 	cmds = append(cmds, func() tea.Msg {
 		_, err := a.Client.Session.Prompt(ctx, a.Session.ID, opencode.SessionPromptParams{
+			Directory: opencode.F(a.Project.Worktree),
 			Model: opencode.F(opencode.SessionPromptParamsModel{
 				ProviderID: opencode.F(a.Provider.ID),
 				ModelID:    opencode.F(a.Model.ID),
@@ -832,6 +848,7 @@ func (a *App) SendCommand(ctx context.Context, command string, args string) (*Ap
 
 	cmds = append(cmds, func() tea.Msg {
 		params := opencode.SessionCommandParams{
+			Directory: opencode.F(a.Project.Worktree),
 			Command:   opencode.F(command),
 			Arguments: opencode.F(args),
 			Agent:     opencode.F(a.Agents[a.AgentIndex].Name),
@@ -872,8 +889,9 @@ func (a *App) SendShell(ctx context.Context, command string) (*App, tea.Cmd) {
 			context.Background(),
 			a.Session.ID,
 			opencode.SessionShellParams{
-				Agent:   opencode.F(a.Agent().Name),
-				Command: opencode.F(command),
+				Directory: opencode.F(a.Project.Worktree),
+				Agent:     opencode.F(a.Agent().Name),
+				Command:   opencode.F(command),
 			},
 		)
 		if err != nil {
@@ -895,7 +913,9 @@ func (a *App) Cancel(ctx context.Context, sessionID string) error {
 		a.compactCancel = nil
 	}
 
-	_, err := a.Client.Session.Abort(ctx, sessionID, opencode.SessionAbortParams{})
+	_, err := a.Client.Session.Abort(ctx, sessionID, opencode.SessionAbortParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		slog.Error("Failed to cancel session", "error", err)
 		return err
@@ -904,7 +924,9 @@ func (a *App) Cancel(ctx context.Context, sessionID string) error {
 }
 
 func (a *App) ListSessions(ctx context.Context) ([]opencode.Session, error) {
-	response, err := a.Client.Session.List(ctx, opencode.SessionListParams{})
+	response, err := a.Client.Session.List(ctx, opencode.SessionListParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +938,9 @@ func (a *App) ListSessions(ctx context.Context) ([]opencode.Session, error) {
 }
 
 func (a *App) DeleteSession(ctx context.Context, sessionID string) error {
-	_, err := a.Client.Session.Delete(ctx, sessionID, opencode.SessionDeleteParams{})
+	_, err := a.Client.Session.Delete(ctx, sessionID, opencode.SessionDeleteParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		slog.Error("Failed to delete session", "error", err)
 		return err
@@ -936,7 +960,9 @@ func (a *App) UpdateSession(ctx context.Context, sessionID string, title string)
 }
 
 func (a *App) ListMessages(ctx context.Context, sessionId string) ([]Message, error) {
-	response, err := a.Client.Session.Messages(ctx, sessionId, opencode.SessionMessagesParams{})
+	response, err := a.Client.Session.Messages(ctx, sessionId, opencode.SessionMessagesParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -958,7 +984,9 @@ func (a *App) ListMessages(ctx context.Context, sessionId string) ([]Message, er
 }
 
 func (a *App) ListProviders(ctx context.Context) ([]opencode.Provider, error) {
-	response, err := a.Client.App.Providers(ctx, opencode.AppProvidersParams{})
+	response, err := a.Client.App.Providers(ctx, opencode.AppProvidersParams{
+		Directory: opencode.F(a.Project.Worktree),
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

TUI doesn't pass `directory` parameter in API calls, causing server to use `process.cwd()` instead of user's project directory.

**Symptom:** `/sessions` shows empty in EXISTING projects despite sessions existing in storage.

Fixes #3026

## Root Cause

The issue had **three components**:
1. **Go TUI API calls** didn't pass Directory parameter
2. **TypeScript CLI** used polluted process.cwd() after wrapper script changed directories  
3. **Go TUI** used os.Getwd() which returned changed directory instead of original

## Solution

Use `OPENCODE_ORIGINAL_CWD` environment variable (set by wrapper script) across all components.

## Changes

Added `Directory` parameter to all **18 API param locations** + **3 env var readers**:

**packages/tui/cmd/opencode/main.go:**
- Read OPENCODE_ORIGINAL_CWD env var, fallback to os.Getwd()
- Pass to 4 API calls: ProjectCurrentParams, AgentListParams, PathGetParams, EventListParams

**packages/tui/internal/app/app.go:**
- Read OPENCODE_ORIGINAL_CWD env var, fallback to project worktree
- Pass to 14 API calls (Configuration, Session CRUD, Session Interactions)

**packages/opencode/src/cli/cmd/tui.ts:**
- Read OPENCODE_ORIGINAL_CWD env var, fallback to process.cwd()
- Used as working directory for TUI spawn

## Testing

- ✅ Go build passes
- ✅ go vet passes (no warnings)
- ✅ Typecheck passes
- ✅ Code follows OpenCode conventions
- ✅ Complete fix across all layers (TypeScript CLI → Go TUI → API calls)

## Files Changed

```
packages/opencode/src/cli/cmd/tui.ts |  2 +-
packages/tui/cmd/opencode/main.go    | 31 ++++++++++++++++++---
packages/tui/internal/app/app.go     | 52 +++++++++++++++++++++++++++---------
3 files changed, 68 insertions(+), 17 deletions(-)
```

## Compliance

✅ Bug fix (accepted by OpenCode guidelines)
✅ Minimal, targeted changes only
✅ No formatting changes included
✅ No SDK regeneration needed
✅ Wrapper script dependency documented (sets OPENCODE_ORIGINAL_CWD)