### PR TITLE
fix(auth): prevent deadlock and race condition (#37)

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { Global } from "../global"
 import fs from "fs/promises"
 import z from "zod"
+import { Lock } from "../util/lock"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -43,31 +44,75 @@ export namespace Auth {
   }
 
   export async function all(): Promise<Record<string, Info>> {
-    const file = Bun.file(filepath)
-    const data = await file.json().catch(() => ({}) as Record<string, unknown>)
-    return Object.entries(data).reduce(
-      (acc, [key, value]) => {
-        const parsed = Info.safeParse(value)
-        if (!parsed.success) return acc
-        acc[key] = parsed.data
-        return acc
-      },
-      {} as Record<string, Info>,
-    )
+    const release = await Lock.read("auth")
+    try {
+      const file = Bun.file(filepath)
+      
+      if (!(await file.exists())) return {}
+      
+      const data = await file.json()
+      
+      if (typeof data !== "object" || data === null) {
+        throw new Error("auth.json contains invalid data")
+      }
+      
+      return Object.entries(data).reduce(
+        (acc, [key, value]) => {
+          const parsed = Info.safeParse(value)
+          if (!parsed.success) return acc
+          acc[key] = parsed.data
+          return acc
+        },
+        {} as Record<string, Info>,
+      )
+    } finally {
+      release[Symbol.dispose]()
+    }
   }
 
   export async function set(key: string, info: Info) {
-    const file = Bun.file(filepath)
-    const data = await all()
-    await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    const release = await Lock.write("auth")
+    try {
+      const file = Bun.file(filepath)
+      const exists = await file.exists()
+      const rawData = exists ? await file.json() : null
+      const data: Record<string, Info> = {}
+
+      if (typeof rawData === "object" && rawData !== null) {
+        Object.entries(rawData).forEach(([k, v]) => {
+          const parsed = Info.safeParse(v)
+          if (parsed.success) data[k] = parsed.data
+        })
+      }
+
+      data[key] = info
+      await Bun.write(file, JSON.stringify(data, null, 2))
+      await fs.chmod(filepath, 0o600)
+    } finally {
+      release[Symbol.dispose]()
+    }
   }
 
   export async function remove(key: string) {
-    const file = Bun.file(filepath)
-    const data = await all()
-    delete data[key]
-    await Bun.write(file, JSON.stringify(data, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    const release = await Lock.write("auth")
+    try {
+      const file = Bun.file(filepath)
+      const exists = await file.exists()
+      const rawData = exists ? await file.json() : null
+      const data: Record<string, Info> = {}
+
+      if (typeof rawData === "object" && rawData !== null) {
+        Object.entries(rawData).forEach(([k, v]) => {
+          const parsed = Info.safeParse(v)
+          if (parsed.success) data[k] = parsed.data
+        })
+      }
+
+      delete data[key]
+      await Bun.write(file, JSON.stringify(data, null, 2))
+      await fs.chmod(filepath, 0o600)
+    } finally {
+      release[Symbol.dispose]()
+    }
   }
 }


### PR DESCRIPTION
Fixes #37 - Critical fix for auth.json race condition causing provider credentials to disappear.

## Changes
- Read file directly in set()/remove() instead of calling all()
- Eliminates nested lock acquisition deadlock
- Maintains file locking for cross-call synchronization

## Testing
- Typecheck passes
- Adversarial review identified deadlock, now fixed