### PR TITLE
fix(processor): handle abort signal during cleanup (#11)

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -363,7 +363,12 @@ export namespace SessionProcessor {
                 message: retry,
                 next: Date.now() + delay,
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
+              await SessionRetry.sleep(delay, input.abort).catch((err) => {
+                if (err?.name === "AbortError") {
+                  log.info("Sleep aborted, checking signal before retry")
+                }
+              })
+              if (input.abort.aborted) break
               continue
             }
             input.assistantMessage.error = error
@@ -377,22 +382,21 @@ export namespace SessionProcessor {
           // and wrap in catch to prevent unhandled promise rejections
           const aborted = input.abort.aborted
           if (snapshot && !aborted) {
-            await Snapshot.patch(snapshot)
-              .then(async (patch) => {
-                if (patch.files.length) {
-                  await Session.updatePart({
-                    id: Identifier.ascending("part"),
-                    messageID: input.assistantMessage.id,
-                    sessionID: input.sessionID,
-                    type: "patch",
-                    hash: patch.hash,
-                    files: patch.files,
-                  })
-                }
-              })
-              .catch((err) => {
-                log.error("cleanup patch failed", { error: err })
-              })
+            try {
+              const patch = await Snapshot.patch(snapshot)
+              if (patch.files.length && !input.abort.aborted) {
+                await Session.updatePart({
+                  id: Identifier.ascending("part"),
+                  messageID: input.assistantMessage.id,
+                  sessionID: input.sessionID,
+                  type: "patch",
+                  hash: patch.hash,
+                  files: patch.files,
+                })
+              }
+            } catch (err) {
+              log.error("cleanup patch failed", { error: err })
+            }
             snapshot = undefined
           }
 
@@ -401,6 +405,10 @@ export namespace SessionProcessor {
             await MessageV2.parts(input.assistantMessage.id)
               .then(async (parts) => {
                 for (const part of parts) {
+                  if (input.abort.aborted) {
+                    log.warn("Cleanup interrupted by abort - partial tool state")
+                    break
+                  }
                   if (part.type === "tool" && part.state.status !== "completed" && part.state.status !== "error") {
                     await Session.updatePart({
                       ...part,
@@ -424,10 +432,14 @@ export namespace SessionProcessor {
               })
           }
 
-          input.assistantMessage.time.completed = Date.now()
-          await Session.updateMessage(input.assistantMessage).catch((err) => {
-            log.error("cleanup message update failed", { error: err })
-          })
+          if (!input.abort.aborted) {
+            try {
+              input.assistantMessage.time.completed = Date.now()
+              await Session.updateMessage(input.assistantMessage)
+            } catch (err) {
+              log.error("cleanup message update failed", { error: err })
+            }
+          }
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"


### PR DESCRIPTION
Fixes #11

## Changes
- Add abort check after retry sleep to prevent infinite loop
- Check abort before and after snapshot patch operation
- Log warning when cleanup interrupted mid-tool-loop
- Move completed time assignment inside abort check with try/catch
- Add logging for aborted sleep

## Testing
- Typecheck passes
- Addresses all 5 critical issues from adversarial review