### PR TITLE
fix(tool): restore accidentally removed GlobTool

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -1,6 +1,7 @@
 import { QuestionTool } from "./question"
 import { BashTool } from "./bash"
 import { EditTool } from "./edit"
+import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
 import { BatchTool } from "./batch"
 import { ReadTool } from "./read"
@@ -98,6 +99,7 @@ export namespace ToolRegistry {
       ...(["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT) ? [QuestionTool] : []),
       BashTool,
       ReadTool,
+      GlobTool,
       GrepTool,
       EditTool,
       WriteTool,


### PR DESCRIPTION
Fixes agents not having access to glob tool.

GlobTool was accidentally removed in commit b1f770a61 during build fixes.
This restores the import and registration in registry.ts.