### PR TITLE
fix(session): release task slots before cleanup on session reset (#33)

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -863,9 +863,22 @@ export namespace Session {
     const { cleanupSessionTaskMaps } = await import("../tool/task")
     await cleanupSessionTaskMaps(sessionID)
 
+    // Create snapshot of entries before iteration to avoid concurrent modification issues
+    const pendingEntries = Array.from(pendingTaskMetadata.entries())
+
+    for (const [id, metadata] of pendingEntries) {
+      if (metadata.session_id === sessionID && metadata.release_slot) {
+        try {
+          metadata.release_slot()
+        } catch (e) {
+          const error = e instanceof Error ? e.message : String(e)
+          log.warn("failed to release task slot during cleanup", { task_id: id, session_id: sessionID, error })
+        }
+      }
+    }
+
     reservedTaskSlots.delete(sessionID)
 
-    const pendingEntries = Array.from(pendingTaskMetadata.entries())
     const cancelNeeded = pendingEntries.some(([_, metadata]) => metadata.session_id === sessionID)
 
     if (cancelNeeded) {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -276,7 +276,7 @@ export const TaskTool = Tool.define("task", async (initCtx) => {
       const taskMetadata: TaskMetadata = {
         agent_type: agent.name,
         description: params.description,
-        session_id: ctx.sessionID,
+        session_id: session.id,
         start_time: startTime,
         release_slot: result.releaseSlot,
       }


### PR DESCRIPTION
## Summary
- Release all task slots before deleting reservedTaskSlots map during cleanup
- Use snapshot of pendingTaskMetadata to avoid race conditions during iteration
- Add error logging for slot cleanup failures

Fixes #33