### PR TITLE
feat(opencode): embed backend in oclite binary (#128)

### DIFF
--- a/packages/opencode/src/cli/ink/entry.ts
+++ b/packages/opencode/src/cli/ink/entry.ts
@@ -15,6 +15,18 @@ async function main() {
       level: "INFO",
     })
 
+    process.on("unhandledRejection", (e) => {
+      Log.Default.error("rejection", {
+        e: e instanceof Error ? e.message : e,
+      })
+    })
+
+    process.on("uncaughtException", (e) => {
+      Log.Default.error("exception", {
+        e: e instanceof Error ? e.message : e,
+      })
+    })
+
     await Instance.provide({
       directory: process.cwd(),
       init: InstanceBootstrap,
@@ -28,4 +40,7 @@ async function main() {
   }
 }
 
-main()
+main().catch((error) => {
+  console.error("Fatal error:", error)
+  process.exit(1)
+})

--- a/packages/opencode/src/cli/ink/entry.ts
+++ b/packages/opencode/src/cli/ink/entry.ts
@@ -3,19 +3,29 @@ import { Global } from "@/global"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
+import { Installation } from "@/installation"
 import { startInkTUI } from "./index.tsx"
 
 async function main() {
-  await Global.init()
-  await Log.init({ print: false, dev: false, level: "INFO" })
+  try {
+    await Global.init()
+    await Log.init({
+      print: process.stdout.isTTY,
+      dev: Installation.isLocal(),
+      level: "INFO",
+    })
 
-  await Instance.provide({
-    directory: process.cwd(),
-    init: InstanceBootstrap,
-    fn: async () => {
-      startInkTUI()
-    },
-  })
+    await Instance.provide({
+      directory: process.cwd(),
+      init: InstanceBootstrap,
+      fn: async () => {
+        await startInkTUI()
+      },
+    })
+  } catch (error) {
+    console.error("Failed to start oclite:", error)
+    process.exit(1)
+  }
 }
 
 main()

--- a/packages/opencode/src/cli/ink/entry.ts
+++ b/packages/opencode/src/cli/ink/entry.ts
@@ -1,5 +1,21 @@
 #!/usr/bin/env bun
-/** @jsxImportSource react */
+import { Global } from "@/global"
+import { Log } from "@/util/log"
+import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { startInkTUI } from "./index.tsx"
 
-startInkTUI()
+async function main() {
+  await Global.init()
+  await Log.init({ print: false, dev: false, level: "INFO" })
+
+  await Instance.provide({
+    directory: process.cwd(),
+    init: InstanceBootstrap,
+    fn: async () => {
+      startInkTUI()
+    },
+  })
+}
+
+main()

--- a/packages/opencode/src/cli/ink/index.tsx
+++ b/packages/opencode/src/cli/ink/index.tsx
@@ -3,5 +3,6 @@ import { render } from "ink"
 import App from "./App"
 
 export function startInkTUI() {
-  render(<App />)
+  const instance = render(<App />)
+  return instance.waitUntilExit()
 }


### PR DESCRIPTION
## Summary
- Adds proper backend bootstrap to oclite entry.ts
- Initializes Global, Log, and Instance.provide() before TUI starts
- Fixes 'No context found' errors when running standalone

Fixes #128