### PR TITLE
fix(oclite): configure React JSX for Ink TUI build (#136)

### DIFF
--- a/packages/opencode/script/build-lite.ts
+++ b/packages/opencode/script/build-lite.ts
@@ -16,6 +16,9 @@ async function build() {
   await fs.promises.mkdir(BIN, { recursive: true })
 
   // Build with NODE_ENV=production to avoid devtools
+  // Explicitly set JSX to use React for Ink components.
+  // oclite uses React/Ink (src/cli/ink/), not SolidJS (src/cli/cmd/tui/).
+  // This overrides the global tsconfig jsxImportSource: "@opentui/solid" setting.
   const result = await Bun.build({
     entrypoints: [path.join(ROOT, "src/cli/ink/entry.ts")],
     outdir: BIN,
@@ -25,6 +28,10 @@ async function build() {
     naming: "oclite",
     define: {
       "process.env.NODE_ENV": '"production"',
+    },
+    jsx: {
+      runtime: "automatic",
+      importSource: "react",
     },
   })
 

--- a/packages/opencode/src/cli/ink/entry.ts
+++ b/packages/opencode/src/cli/ink/entry.ts
@@ -9,8 +9,9 @@ import { startInkTUI } from "./index.tsx"
 async function main() {
   try {
     await Global.init()
+    // Disable Log printing to stdout - Ink owns stdout for TUI rendering
     await Log.init({
-      print: process.stdout.isTTY,
+      print: false,
       dev: Installation.isLocal(),
       level: "INFO",
     })


### PR DESCRIPTION
## Summary

Fixes #136 - oclite TUI fails to render due to React hooks error.

### Root Cause
- Global `tsconfig.json` has `jsxImportSource: "@opentui/solid"` for main TUI
- oclite uses React/Ink in `src/cli/ink/`
- Bun.build was using SolidJS JSX transform, breaking React hooks

### Solution
1. **Explicit JSX config in build-lite.ts**: Set `jsx: { runtime: "automatic", importSource: "react" }` in Bun.build
2. **Disable Log stdout**: Set `print: false` in entry.ts to avoid conflicts with Ink's stdout rendering

### Verification
- ✅ Typecheck passes
- ✅ All 1298 tests pass
- ✅ Binary builds successfully (8.84 MB)
- ✅ TUI renders without React hooks error
- ✅ Adversarial review: APPROVED

### Build Isolation
- oclite (React/Ink): `src/cli/ink/` - separate build via build-lite.ts
- Main TUI (SolidJS): `src/cli/cmd/tui/` - separate build
- No cross-dependencies between them

### Testing
```bash
bun run typecheck  # Pass
bun test          # 1298 pass
bun run build:lite # Success
~/bin/oclite      # TUI renders
```