### PR TITLE
feat(opencode): enable 1M context + adaptive thinking for Opus 4.6 (#150)

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -73,7 +73,7 @@ export namespace Provider {
         options: {
           headers: {
             "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,adaptive-thinking-2026-01-28,context-1m-2025-08-07",
           },
         },
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -447,8 +447,33 @@ export namespace ProviderTransform {
 
       case "@ai-sdk/anthropic":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
-      case "@ai-sdk/google-vertex/anthropic":
+      case "@ai-sdk/google-vertex/anthropic": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
+        const modelId = model.id || ""
+        const isOpus46 =
+          modelId.includes("claude-opus-4.6") ||
+          modelId.includes("claude-opus-4-6") ||
+          modelId.includes("claude-opus-4.6")
+
+        if (isOpus46) {
+          // Opus 4.6 uses adaptive thinking with effort levels
+          return {
+            high: {
+              thinking: {
+                type: "enabled",
+                effort: "high",
+              },
+            },
+            max: {
+              thinking: {
+                type: "enabled",
+                effort: "max",
+              },
+            },
+          }
+        }
+
+        // Older models use manual thinking with budgetTokens
         return {
           high: {
             thinking: {
@@ -463,6 +488,7 @@ export namespace ProviderTransform {
             },
           },
         }
+      }
 
       case "@ai-sdk/amazon-bedrock":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock


### PR DESCRIPTION
## Summary
Minimal port of upstream #12338 to enable 1M context window and adaptive thinking for Claude Opus 4.6.

## Changes
- Added `context-1m-2025-08-07` and `adaptive-thinking-2026-01-28` beta headers to Anthropic provider
- Added Opus 4.6 model detection (claude-opus-4.6 / claude-opus-4-6)
- Opus 4.6 uses effort-based adaptive thinking (high/max) instead of fixed budgetTokens
- No dependency changes required

## Testing
- TypeScript typecheck passes
- All 1308 tests pass
- Manual testing needed: Opus 4.6 with >200k tokens

## Upstream Reference
- Issue: anomalyco/opencode#12338
- PR: anomalyco/opencode#12342

Fixes #150