### PR TITLE
fix(#178): route task results to parent session via correct session ID

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -27,7 +27,8 @@
         "formatCompletedTasksForInjection",
         "TaskTool",
         "CheckTaskTool",
-        "Agent.get(task.agent)"
+        "Agent.get(task.agent)",
+        "parent_session_id"
       ],
       "tests": ["packages/opencode/test/tool/check_task.test.ts"],
       "upstreamTracking": {

--- a/packages/opencode/src/session/async-tasks.ts
+++ b/packages/opencode/src/session/async-tasks.ts
@@ -27,6 +27,7 @@ export interface TaskMetadata {
   agent_type: string
   description: string
   session_id: string
+  parent_session_id: string
   start_time: number
   release_slot?: () => void
 }
@@ -216,7 +217,7 @@ export async function trackBackgroundTask(
     }
     if (sessionID) {
       if (!closingSessions.has(sessionID)) {
-        const parentSessionID = metadata?.session_id
+        const parentSessionID = metadata?.parent_session_id
         if (taskResult.status === "completed") {
           Bus.publish(BackgroundTaskEvent.Completed, { taskID: id, sessionID, parentSessionID })
         }
@@ -251,7 +252,7 @@ export async function trackBackgroundTask(
     }
     if (sessionID) {
       if (!closingSessions.has(sessionID)) {
-        const parentSessionID = metadata?.session_id
+        const parentSessionID = metadata?.parent_session_id
         Bus.publish(BackgroundTaskEvent.Failed, {
           taskID: id,
           sessionID,
@@ -325,7 +326,7 @@ export function getAndClearCompletedTasks(sessionID: string): BackgroundTaskResu
   const completedTasks: BackgroundTaskResult[] = []
 
   for (const [id, result] of backgroundTaskResults.entries()) {
-    const isFromSession = result.metadata?.session_id === sessionID
+    const isFromSession = result.metadata?.parent_session_id === sessionID
     const isCompletedOrFailed = result.status === "completed" || result.status === "failed"
 
     if (!isCompletedOrFailed || !isFromSession) {
@@ -351,7 +352,7 @@ export function getAndClearCompletedTasks(sessionID: string): BackgroundTaskResu
 
 export function hasUndeliveredCompletedTasks(sessionID: string): boolean {
   for (const [id, result] of backgroundTaskResults.entries()) {
-    const isFromSession = result.metadata?.session_id === sessionID
+    const isFromSession = result.metadata?.parent_session_id === sessionID
     const isCompletedOrFailed = result.status === "completed" || result.status === "failed"
     const alreadyDelivered = deliveredTaskResults.has(id)
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -290,7 +290,8 @@ export const TaskTool = Tool.define("task", async (initCtx) => {
       const taskMetadata: TaskMetadata = {
         agent_type: agent.name,
         description: params.description,
-        session_id: ctx.sessionID,
+        session_id: session.id,
+        parent_session_id: ctx.sessionID,
         start_time: startTime,
         release_slot: result.releaseSlot,
       }
@@ -324,7 +325,7 @@ export const TaskTool = Tool.define("task", async (initCtx) => {
               unsub()
             }
           })(),
-          session.id,
+          ctx.sessionID,
           taskMetadata,
         )
       } catch (e) {


### PR DESCRIPTION
## Summary
- Fixed session ID mismatch causing async task results to never reach parent agent
- Added `parent_session_id` to typeMetadata for explicit parent/child separation
- Results now stored and retrieved by parent session ID
- Auto-wakeup events correctly target parent session
- Updated fork-features manifest with new criticalCode marker

## Changes
- `async-tasks.ts`: Added `parent_session_id` field, updated 4 lookups to use it
- `task.ts`: Set `session_id` to child, `parent_session_id` to parent, pass parent as tracking key

Fixes #178