### PR TITLE
fix(async-tasks): mark task completion injection as synthetic

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -164,7 +164,7 @@ export namespace SessionPrompt {
     const completedTasks = getAndClearCompletedTasks(input.sessionID)
     if (completedTasks.length > 0) {
       const injectionText = formatCompletedTasksForInjection(completedTasks)
-      input = { ...input, parts: [...input.parts, { type: "text", text: injectionText }] }
+      input = { ...input, parts: [...input.parts, { type: "text", text: injectionText, synthetic: true }] }
     }
 
     const message = await createUserMessage(input)


### PR DESCRIPTION
Fixes #196

One-line fix: adds `synthetic: true` to task completion injection in prompt.ts so it does not render as a user message in the TUI.