### PR TITLE
fix(taskctl): capture final composer response via Bus completion event

### DIFF
--- a/packages/opencode/src/tasks/composer.ts
+++ b/packages/opencode/src/tasks/composer.ts
@@ -2,6 +2,8 @@ import z from "zod"
 import { Session } from "../session"
 import { SessionPrompt } from "../session/prompt"
 import { MessageV2 } from "../session/message-v2"
+import { BackgroundTaskEvent } from "../session/async-tasks"
+import { Bus } from "../bus"
 import { Store } from "./store"
 import { Validation } from "./validation"
 import { generateUniqueSlug, slugify } from "./tool"
@@ -39,20 +41,35 @@ async function defaultSpawnComposerFn(
 
   await SessionPrompt.prompt({ sessionID: session.id, agent: "composer", parts: [{ type: "text", text: prompt }] })
 
-  const timeout = new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), timeoutMs))
+  const finalText = await new Promise<string | undefined>((resolve) => {
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve(undefined)
+    }, timeoutMs)
 
-  const messages = Promise.resolve().then(async () => {
-    let lastAssistantText: string | undefined
-    for await (const msg of MessageV2.stream(session.id)) {
-      if (msg.info.role === "assistant") {
-        const textPart = msg.parts.find((p) => p.type === "text" && !p.synthetic)
-        if (textPart && "text" in textPart) lastAssistantText = textPart.text
-      }
+    const cleanup = () => {
+      unsub1()
+      unsub2()
+      clearTimeout(timer)
     }
-    return lastAssistantText
+
+    const handler = (event: { properties: { parentSessionID?: string } }) => {
+      if (event.properties.parentSessionID !== sessionID) return
+      cleanup()
+      // Stream is descending order (newest first) — .find() gets the NEWEST assistant message
+      ;(async () => {
+        const msgs = await Array.fromAsync(MessageV2.stream(session.id))
+        const last = msgs.find((m) => m.info.role === "assistant")
+        const textPart = last?.parts.find((p) => p.type === "text" && !p.synthetic)
+        resolve(textPart && "text" in textPart ? textPart.text : undefined)
+      })().catch(() => resolve(undefined))
+    }
+
+    const unsub1 = Bus.subscribe(BackgroundTaskEvent.Completed, handler)
+    const unsub2 = Bus.subscribe(BackgroundTaskEvent.Failed, handler)
   })
 
-  return await Promise.race([messages, timeout])
+  return finalText
 }
 
 export async function runComposer(
@@ -82,7 +99,7 @@ Decompose this issue into a dependency-ordered list of implementation tasks. Ret
   try {
     parsed = JSON.parse(output)
   } catch {
-    throw new Error("Composer agent returned invalid JSON")
+    throw new Error(`Composer agent returned invalid JSON. Raw (first 500 chars): ${output.substring(0, 500)}`)
   }
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {


### PR DESCRIPTION
## Summary

Fixes two bugs in `defaultSpawnComposerFn` in `packages/opencode/src/tasks/composer.ts` that caused `taskctl start` to throw "Composer agent returned invalid JSON" even when the agent returned valid JSON.

**Bug 1 — Wrong message captured**: `MessageV2.stream()` returns messages in descending order (newest-first). The old loop overwrote `lastAssistantText` on every iteration, ending up with the oldest assistant message (a partial/preamble chunk) instead of the final complete JSON response.

**Bug 2 — Race condition**: The stream read existing DB rows in a snapshot. If the agent hadn't finished writing its final message yet, it wouldn't be present.

## Fix

Replaces the `Promise.race([messages, timeout])` approach with a `Bus.subscribe(BackgroundTaskEvent.Completed/Failed)` event-based wait. After the event fires, `Array.fromAsync(MessageV2.stream())` + `.find()` correctly retrieves the newest assistant message. Async IIFE has `.catch(() => resolve(undefined))` to prevent unhandled rejection if the stream throws.

Also improves the `JSON.parse` error message to include the first 500 chars of raw response for debuggability.

Fixes #230