### PR TITLE
fix(taskctl): strip markdown code fences from Composer response before JSON.parse

### DIFF
--- a/packages/opencode/src/tasks/composer.ts
+++ b/packages/opencode/src/tasks/composer.ts
@@ -86,9 +86,11 @@ Decompose this issue into a dependency-ordered list of implementation tasks. Ret
   const output = await spawn(composerPrompt)
   if (!output) throw new Error("Composer agent timed out or returned no response")
 
+  // Strip markdown code fences if present — anchored to string start/end, no multiline flag
+  const cleaned = output.replace(/^```(?:json)?\r?\n([\s\S]*?)\r?\n```\s*$/, "$1").trim()
   let parsed: unknown
   try {
-    parsed = JSON.parse(output)
+    parsed = JSON.parse(cleaned)
   } catch {
     throw new Error(`Composer agent returned invalid JSON. Raw (first 500 chars): ${output.substring(0, 500)}`)
   }


### PR DESCRIPTION
## Summary

The Composer agent sometimes wraps its JSON response in markdown code fences (` ``json ... ``` `), causing `JSON.parse` to fail even though the JSON content is valid.

Adds a single regex to strip fences before parsing, anchored to string start/end (no `m` flag to avoid corrupting JSON strings containing backticks):

```typescript
const cleaned = output.replace(/^\`\`\`(?:json)?\r?\n([\s\S]*?)\r?\n\`\`\`\s*$/, "$1").trim()
```

- `\r?\n` handles both Unix and Windows line endings
- `[\s\S]*?` non-greedy stops at first closing fence
- No `m` flag — `^`/`$` anchor to string boundaries only, won't corrupt JSON values containing backtick sequences
- If no fence present, `output` is returned unchanged

Two rounds of adversarial review completed before merge.

Fixes #237