### PR TITLE
fix(taskctl): findJobByIssue returns most recent running job (#242)

### DIFF
--- a/packages/opencode/src/tasks/store.ts
+++ b/packages/opencode/src/tasks/store.ts
@@ -87,6 +87,18 @@ function validateTaskUpdates(updates: Partial<Task>, allowImmutable: boolean = f
   }
 }
 
+function isValidJob(job: unknown): job is Job {
+  if (!job || typeof job !== "object") return false
+  const j = job as Partial<Job>
+  if (typeof j.id !== "string") return false
+  if (typeof j.parent_issue !== "number") return false
+  if (typeof j.created_at !== "string") return false
+  const time = new Date(j.created_at).getTime()
+  if (isNaN(time)) return false
+  if (!["running", "stopped", "complete", "failed"].includes(j.status as string)) return false
+  return true
+}
+
 export const Store = {
   async createTask(projectId: string, task: Task): Promise<void> {
     sanitizeTaskId(task.id)
@@ -265,30 +277,21 @@ export const Store = {
 
   async findJobByIssue(projectId: string, issueNumber: number): Promise<Job | null> {
     const tasksDir = await getTasksDir(projectId)
-    const jobPattern = /^job-(.+)\.json$/
-    const jobFiles = [];
-
-    try {
-      const entries = await fs.readdir(tasksDir);
-      for (const entry of entries) {
-        const match = jobPattern.exec(entry);
-        if (match) {
-          const jobPath = path.join(tasksDir, entry);
-          const content = await Bun.file(jobPath).text().catch(() => null);
-          if (content) {
-            try {
-              const job = JSON.parse(content) as Job;
-              if (job.parent_issue === issueNumber && job.status === "running") {
-                return job;
-              }
-            } catch {}
-          }
-        }
-      }
-    } catch {
-      return null;
+    const entries = await fs.readdir(tasksDir).catch(() => [] as string[])
+    const jobs: Job[] = []
+    for (const entry of entries) {
+      if (!/^job-(.+)\.json$/.test(entry)) continue
+      const content = await Bun.file(path.join(tasksDir, entry)).text().catch(() => null)
+      if (!content) continue
+      try {
+        const parsed = JSON.parse(content)
+        if (!isValidJob(parsed)) continue
+        if (parsed.parent_issue === issueNumber) jobs.push(parsed)
+      } catch {}
     }
-
-    return null;
+    if (jobs.length === 0) return null
+    const time = (j: Job) => new Date(j.created_at).getTime()
+    jobs.sort((a, b) => time(b) - time(a))
+    return jobs.find((j) => j.status === "running") ?? jobs[0]
   },
 }

--- a/packages/opencode/test/tasks/store.test.ts
+++ b/packages/opencode/test/tasks/store.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, test } from "bun:test"
 import { Store } from "../../src/tasks/store"
-import type { Task } from "../../src/tasks/types"
+import type { Task, Job } from "../../src/tasks/types"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import { randomUUID } from "crypto"
+import fs from "fs/promises"
 
 function getProjectId(): string {
   return `test-store-${randomUUID()}`
+}
+
+function createJob(override: Partial<Job>): Job {
+  return {
+    id: `job-${randomUUID()}`,
+    parent_issue: 1,
+    status: "running",
+    created_at: new Date().toISOString(),
+    stopping: false,
+    pulse_pid: null,
+    max_workers: 4,
+    pm_session_id: randomUUID(),
+    ...override,
+  }
 }
 
 function isValidISODate(dateStr: string): boolean {
@@ -230,5 +245,169 @@ describe("store: task operations", () => {
     if (!updated.comments[0]) throw new Error("Comment not found")
     expect(updated.comments[0].author).toBe("test-agent")
     expect(updated.comments[0].message).toBe("Test comment")
+  })
+})
+
+describe("store: findJobByIssue", () => {
+  test("returns most recent running job when multiple jobs exist", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const olderDate = new Date(Date.now() - 60000).toISOString()
+    const newerDate = new Date(Date.now() - 30000).toISOString()
+
+    const olderJob = createJob({ parent_issue: 1, status: "running", created_at: olderDate })
+    const newerJob = createJob({ parent_issue: 1, status: "running", created_at: newerDate })
+
+    await Store.createJob(projectId, olderJob)
+    await Store.createJob(projectId, newerJob)
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(newerJob.id)
+    expect(found!.created_at).toBe(newerDate)
+  })
+
+  test("returns most recently created stopped job if no running job", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const olderDate = new Date(Date.now() - 60000).toISOString()
+    const newerDate = new Date(Date.now() - 30000).toISOString()
+
+    const olderJob = createJob({ parent_issue: 1, status: "stopped", created_at: olderDate })
+    const newerJob = createJob({ parent_issue: 1, status: "stopped", created_at: newerDate })
+
+    await Store.createJob(projectId, olderJob)
+    await Store.createJob(projectId, newerJob)
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(newerJob.id)
+    expect(found!.status).toBe("stopped")
+  })
+
+  test("prefers running job over newer stopped job", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const olderDate = new Date(Date.now() - 60000).toISOString()
+    const newerDate = new Date(Date.now() - 30000).toISOString()
+
+    const runningJob = createJob({ parent_issue: 1, status: "running", created_at: olderDate })
+    const stoppedJob = createJob({ parent_issue: 1, status: "stopped", created_at: newerDate })
+
+    await Store.createJob(projectId, runningJob)
+    await Store.createJob(projectId, stoppedJob)
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(runningJob.id)
+    expect(found!.status).toBe("running")
+  })
+
+  test("returns null when no jobs exist for issue", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+
+    const found = await Store.findJobByIssue(projectId, 999)
+    expect(found).toBeNull()
+  })
+
+  test("ignores jobs for different issue numbers", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+
+    const job1 = createJob({ parent_issue: 1, status: "running" })
+    const job2 = createJob({ parent_issue: 2, status: "running" })
+
+    await Store.createJob(projectId, job1)
+    await Store.createJob(projectId, job2)
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(job1.id)
+    expect(found!.parent_issue).toBe(1)
+  })
+
+  test("handles malformed job file gracefully", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const validJob = createJob({ parent_issue: 1, status: "running" })
+
+    await Store.createJob(projectId, validJob)
+    const tasksDir = path.join(tmp.path, "tasks", projectId)
+    await fs.mkdir(tasksDir, { recursive: true })
+    await Bun.write(path.join(tasksDir, "job-invalid.json"), "{ broken json")
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(validJob.id)
+  })
+
+  test("ignores job with missing required fields", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const validJob = createJob({ parent_issue: 1, status: "running" })
+    const tasksDir = path.join(tmp.path, "tasks", projectId)
+
+    await Store.createJob(projectId, validJob)
+    await fs.mkdir(tasksDir, { recursive: true })
+    await Bun.write(
+      path.join(tasksDir, "job-incomplete.json"),
+      JSON.stringify({ id: "incomplete", parent_issue: 1 }),
+    )
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(validJob.id)
+  })
+
+  test("ignores job with invalid created_at date", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const validJob = createJob({ parent_issue: 1, status: "running" })
+    const invalidJob = {
+      id: `job-${randomUUID()}`,
+      parent_issue: 1,
+      status: "running" as const,
+      created_at: "not-a-date",
+      stopping: false,
+      pulse_pid: null,
+      max_workers: 4,
+      pm_session_id: randomUUID(),
+    }
+
+    await Store.createJob(projectId, validJob)
+    await Store.createJob(projectId, invalidJob as Job)
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(validJob.id)
+  })
+
+  test("ignores job with invalid status", async () => {
+    await using tmp = await tmpdir()
+    const projectId = getProjectId()
+    const validJob = createJob({ parent_issue: 1, status: "running" })
+    const tasksDir = path.join(tmp.path, "tasks", projectId)
+
+    await Bun.write(
+      path.join(tasksDir, "job-invalid-status.json"),
+      JSON.stringify({
+        id: `job-${randomUUID()}`,
+        parent_issue: 1,
+        status: "invalidStatus",
+        created_at: new Date().toISOString(),
+        stopping: false,
+        pulse_pid: null,
+        max_workers: 4,
+        pm_session_id: randomUUID(),
+      }),
+    )
+
+    await Store.createJob(projectId, validJob)
+    await fs.mkdir(tasksDir, { recursive: true })
+
+    const found = await Store.findJobByIssue(projectId, 1)
+    expect(found).not.toBeNull()
+    expect(found!.id).toBe(validJob.id)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #242

- `Store.findJobByIssue()` previously returned the first job found for an issue, not the most recent
- Now collects all jobs for the issue, sorts by `created_at` descending, returns most recent running job (falls back to most recent overall if none running)
- Added `isValidJob` type guard for runtime validation
- 7 new tests covering edge cases (malformed JSON, invalid dates, missing fields, status precedence)