### PR TITLE
fix(taskctl): capture and restore Instance context in Pulse setInterval (#243)

### DIFF
--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -11,7 +11,7 @@ interface Context {
   worktree: string
   project: Project.Info
 }
-const context = Context.create<Context>("instance")
+export const context = Context.create<Context>("instance")
 const cache = new Map<string, Promise<Context>>()
 
 const disposal = {

--- a/packages/opencode/src/tasks/pulse.ts
+++ b/packages/opencode/src/tasks/pulse.ts
@@ -13,11 +13,23 @@ import { Log } from "../util/log"
 import { MessageV2 } from "../session/message-v2"
 import { SessionStatus } from "../session/status"
 import type { Task, Job, AdversarialVerdict } from "./types"
+import { Instance, context as instanceContext } from "../project/instance"
+import { GlobalBus } from "../bus/global"
 
 const log = Log.create({ service: "taskctl.pulse" })
 const activeTicks = new Map<string, Set<string>>()
+const intervalListeners = new Map<ReturnType<typeof setInterval>, (event: { directory: string | undefined; payload: any }) => void>()
 
 const TIMEOUT_MS = 30 * 60 * 1000
+
+function clearIntervalSafe(interval: ReturnType<typeof setInterval>) {
+  const listener = intervalListeners.get(interval)
+  if (listener) {
+    GlobalBus.off("event", listener)
+    intervalListeners.delete(interval)
+  }
+  clearInterval(interval)
+}
 
 export function sanitizeWorktree(worktree: string | null | undefined): string | null {
   if (!worktree || typeof worktree !== "string") return null
@@ -26,6 +38,14 @@ export function sanitizeWorktree(worktree: string | null | undefined): string | 
 }
 
 export function startPulse(jobId: string, projectId: string, pmSessionId: string): ReturnType<typeof setInterval> {
+  const capturedCtx = instanceContext.tryGet()
+  if (!capturedCtx) {
+    log.error("refusing to start pulse: no instance context", { jobId, projectId })
+    const noopInterval = setInterval(() => {}, 5_000)
+    clearInterval(noopInterval)
+    return noopInterval
+  }
+
   const startJob = async (): Promise<void> => {
     const existingPid = await readLockPid(jobId, projectId).catch(() => null)
     if (existingPid && isPidAlive(existingPid)) {
@@ -47,29 +67,43 @@ export function startPulse(jobId: string, projectId: string, pmSessionId: string
     activeTicks.set(projectId, projectTicks)
     if (projectTicks.has(jobId)) return
     projectTicks.add(jobId)
-    try {
-      const job = await Store.getJob(projectId, jobId)
-      if (!job) {
-        clearInterval(interval)
+
+    await instanceContext.provide(capturedCtx, async () => {
+      try {
+        const job = await Store.getJob(projectId, jobId)
+        if (!job) {
+          clearIntervalSafe(interval)
+          projectTicks.delete(jobId)
+          return
+        }
+        if (job.stopping) {
+          await gracefulStop(jobId, projectId, interval)
+          return
+        }
+        await heartbeatActiveAgents(jobId, projectId)
+        await processAdversarialVerdicts(jobId, projectId, pmSessionId)
+        await checkTimeouts(jobId, projectId)
+        await checkSteering(jobId, projectId, pmSessionId)
+        await scheduleReadyTasks(jobId, projectId, pmSessionId)
+        await checkCompletion(jobId, projectId, pmSessionId, interval)
+      } catch (e) {
+        log.error("tick failed with unrecoverable error", { jobId, error: String(e) })
+      } finally {
         projectTicks.delete(jobId)
-        return
       }
-      if (job.stopping) {
-        await gracefulStop(jobId, projectId, interval)
-        return
-      }
-      await heartbeatActiveAgents(jobId, projectId)
-      await processAdversarialVerdicts(jobId, projectId, pmSessionId)
-      await checkTimeouts(jobId, projectId)
-      await checkSteering(jobId, projectId, pmSessionId)
-      await scheduleReadyTasks(jobId, projectId, pmSessionId)
-      await checkCompletion(jobId, projectId, pmSessionId, interval)
-    } catch (e) {
-      log.error("tick failed with unrecoverable error", { jobId, error: String(e) })
-    } finally {
-      projectTicks.delete(jobId)
-    }
+    })
   }, 5_000)
+
+  const disposeListener = (event: { directory: string | undefined; payload: any }) => {
+    if (!intervalListeners.has(interval)) return
+    if (event.directory === capturedCtx.directory && event.payload?.type === "server.instance.disposed") {
+      log.info("instance disposed, clearing pulse interval", { jobId, projectId })
+      clearIntervalSafe(interval)
+      activeTicks.get(projectId)?.delete(jobId)
+    }
+  }
+  intervalListeners.set(interval, disposeListener)
+  GlobalBus.on("event", disposeListener)
 
   return interval
 }
@@ -1078,7 +1112,7 @@ export async function checkCompletion(
   if (allClosed) {
     log.info("all tasks completed", { jobId })
     try {
-      clearInterval(interval)
+      clearIntervalSafe(interval)
       activeTicks.get(projectId)?.delete(jobId)
       await removeLockFile(jobId, projectId)
       await Store.updateJob(projectId, jobId, { status: "complete" })
@@ -1143,7 +1177,7 @@ async function gracefulStop(jobId: string, projectId: string, interval: ReturnTy
       })
     }
 
-    clearInterval(interval)
+    clearIntervalSafe(interval)
     await removeLockFile(jobId, projectId)
     await Store.updateJob(projectId, jobId, { status: "stopped" })
   } catch (e) {

--- a/packages/opencode/src/tasks/pulse.ts
+++ b/packages/opencode/src/tasks/pulse.ts
@@ -18,7 +18,7 @@ import { GlobalBus } from "../bus/global"
 
 const log = Log.create({ service: "taskctl.pulse" })
 const activeTicks = new Map<string, Set<string>>()
-const intervalListeners = new Map<ReturnType<typeof setInterval>, (event: { directory: string | undefined; payload: any }) => void>()
+const intervalListeners = new Map<ReturnType<typeof setInterval>, (event: { directory?: string | undefined; payload: any }) => void>()
 
 const TIMEOUT_MS = 30 * 60 * 1000
 
@@ -94,7 +94,7 @@ export function startPulse(jobId: string, projectId: string, pmSessionId: string
     })
   }, 5_000)
 
-  const disposeListener = (event: { directory: string | undefined; payload: any }) => {
+  const disposeListener = (event: { directory?: string | undefined; payload: any }) => {
     if (!intervalListeners.has(interval)) return
     if (event.directory === capturedCtx.directory && event.payload?.type === "server.instance.disposed") {
       log.info("instance disposed, clearing pulse interval", { jobId, projectId })

--- a/packages/opencode/src/util/context.ts
+++ b/packages/opencode/src/util/context.ts
@@ -17,6 +17,9 @@ export namespace Context {
         }
         return result
       },
+      tryGet(): T | undefined {
+        return storage.getStore()
+      },
       provide<R>(value: T, fn: () => R) {
         return storage.run(value, fn)
       },

--- a/packages/opencode/test/tasks/pulse.test.ts
+++ b/packages/opencode/test/tasks/pulse.test.ts
@@ -37,58 +37,64 @@ describe("pulse.ts", () => {
   describe("lock file management", () => {
     test("lock file written on start, removed on completion", async () => {
       const { startPulse, readLockPid } = await import("../../src/tasks/pulse")
+      const { Instance } = await import("../../src/project/instance")
 
-      const mockTask: any = {
-        id: "task-1",
-        job_id: TEST_JOB_ID,
-        status: "closed",
-        priority: 2,
-        task_type: "implementation",
-        parent_issue: 123,
-        labels: [],
-        depends_on: [],
-        assignee: null,
-        assignee_pid: null,
-        worktree: null,
-        branch: null,
-        title: "Test task",
-        description: "Test description",
-        acceptance_criteria: "Test criteria",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        close_reason: null,
-        comments: [],
-        pipeline: {
-          stage: "done",
-          attempt: 0,
-          last_activity: null,
-          last_steering: null,
-          history: [],
-          adversarial_verdict: null,
+      await Instance.provide({
+        directory: testDataDir,
+        fn: async () => {
+          const mockTask: any = {
+            id: "task-1",
+            job_id: TEST_JOB_ID,
+            status: "closed",
+            priority: 2,
+            task_type: "implementation",
+            parent_issue: 123,
+            labels: [],
+            depends_on: [],
+            assignee: null,
+            assignee_pid: null,
+            worktree: null,
+            branch: null,
+            title: "Test task",
+            description: "Test description",
+            acceptance_criteria: "Test criteria",
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            close_reason: null,
+            comments: [],
+            pipeline: {
+              stage: "done",
+              attempt: 0,
+              last_activity: null,
+              last_steering: null,
+              history: [],
+              adversarial_verdict: null,
+            },
+          }
+
+          await Store.createJob(TEST_PROJECT_ID, {
+            id: TEST_JOB_ID,
+            parent_issue: 123,
+            status: "running",
+            created_at: new Date().toISOString(),
+            stopping: false,
+            pulse_pid: null,
+            max_workers: 1,
+            pm_session_id: TEST_PM_SESSION_ID,
+          })
+
+          await Store.createTask(TEST_PROJECT_ID, mockTask)
+
+          const interval = startPulse(TEST_JOB_ID, TEST_PROJECT_ID, TEST_PM_SESSION_ID)
+
+          await new Promise((resolve) => setTimeout(resolve, 100))
+
+          const lockPid = await readLockPid(TEST_JOB_ID, TEST_PROJECT_ID)
+          expect(lockPid).toBe(process.pid)
+
+          clearInterval(interval)
         },
-      }
-
-      await Store.createJob(TEST_PROJECT_ID, {
-        id: TEST_JOB_ID,
-        parent_issue: 123,
-        status: "running",
-        created_at: new Date().toISOString(),
-        stopping: false,
-        pulse_pid: null,
-        max_workers: 1,
-        pm_session_id: TEST_PM_SESSION_ID,
       })
-
-      await Store.createTask(TEST_PROJECT_ID, mockTask)
-
-      const interval = startPulse(TEST_JOB_ID, TEST_PROJECT_ID, TEST_PM_SESSION_ID)
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-
-      const lockPid = await readLockPid(TEST_JOB_ID, TEST_PROJECT_ID)
-      expect(lockPid).toBe(process.pid)
-
-      clearInterval(interval)
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes #243

`setInterval` callbacks run outside the `AsyncLocalStorage` Instance context, causing all Instance-scoped calls (`SessionStatus`, `Store`, `Session`) to fail silently — heartbeat never fired, tasks never transitioned to `reviewing`, adversarial stage was never reached.

### Changes
- `context.ts`: Added `tryGet()` — captures context without throwing
- `instance.ts`: Exported context object for external use  
- `pulse.ts`: Captures Instance context at `startPulse()` call time, wraps entire tick body in `instanceContext.provide(capturedCtx, fn)` to restore context on every tick
- Fail-fast with noop interval when called without Instance context (tests)
- `clearIntervalSafe()` removes GlobalBus listeners to prevent memory leaks
- Disposal listener clears interval when Instance is disposed