### PR TITLE
fix(taskctl): allow restart of complete/stopped jobs and resume with stop flag set (#293)

### DIFF
--- a/packages/opencode/src/tasks/job-commands.ts
+++ b/packages/opencode/src/tasks/job-commands.ts
@@ -17,25 +17,33 @@ export async function executeStart(projectId: string, params: any, ctx: any): Pr
   if (existingJob) {
     const existingPid = await readLockPid(existingJob.id, projectId)
 
-    if (existingJob.status === "complete" || existingJob.status === "failed" || existingJob.status === "stopped") {
-      return {
-        title: "Job already completed",
-        output: `Job is ${existingJob.status}. Status: taskctl status ${issueNumber}`,
-        metadata: {},
-      }
-    }
-
     if (existingJob.status === "running") {
       if (existingPid !== null && isPidAlive(existingPid)) {
         return {
-          title: "Already running",
-          output: `Job already running (PID ${existingPid}). Use taskctl status ${issueNumber} to monitor.`,
+          title: "Job already running",
+          output: `Job is running. Status: taskctl status ${issueNumber}`,
           metadata: {},
         }
       }
       if (existingPid !== null) {
         await removeLockFile(existingJob.id, projectId)
       }
+    }
+
+    // Re-check job existence after lock cleanup to avoid race
+    const recheckedJob = await Store.getJob(projectId, existingJob.id)
+    if (recheckedJob === null) {
+      // Job was deleted by another process, proceed to create new job
+    } else if (recheckedJob.status === "running") {
+      // Another process already started a new job
+      return {
+        title: "Job already running",
+        output: `Job ${recheckedJob.id} is running. Status: taskctl status ${issueNumber}`,
+        metadata: {},
+      }
+    } else {
+      // Delete non-running jobs atomically
+      await Store.deleteJobAndTasks(projectId, existingJob.id)
     }
   }
 
@@ -234,20 +242,20 @@ export async function executeResume(projectId: string, params: any, ctx: any): P
 
   const revalidated = await Store.getJob(projectId, jobId)
   if (!revalidated) throw new Error(`Job vanished after resurrection: ${jobId}`)
-  if (revalidated.stopping === true || revalidated.status === "complete" || revalidated.status === "failed" || revalidated.status === "stopped") {
+  
+  if (revalidated.status !== "stopped") {
     return {
       title: "Cannot resume",
-      output: `Job is ${revalidated.status}${revalidated.stopping ? " and has stop flag set" : ""}. Status: taskctl status`,
+      output: `Job status must be "stopped" to resume. Current status: ${revalidated.status}. Status: taskctl status`,
       metadata: {},
     }
   }
-
-  await Store.updateJob(projectId, jobId, { status: "running", stopping: false })
+  
+  await Store.updateJob(projectId, jobId, { stopping: false, status: "running" })
   enableAutoWakeup(ctx.sessionID)
 
   const tasks = await Store.listTasks(projectId)
   const remaining = tasks.filter((t) => t.job_id === jobId && t.status !== "closed").length
-  await resurrectionScan(jobId, projectId)
   startPulse(jobId, projectId, ctx.sessionID)
 
   return {

--- a/packages/opencode/src/tasks/pulse-monitoring.ts
+++ b/packages/opencode/src/tasks/pulse-monitoring.ts
@@ -407,6 +407,7 @@ export async function gracefulStop(
       })
     }
 
+    await Store.updateJob(projectId, jobId, { status: "stopped", stopping: false })
     await clearIntervalSafe(intervalId)
     log.info("graceful stop completed", { jobId })
   } catch (e) {

--- a/packages/opencode/src/tasks/pulse.ts
+++ b/packages/opencode/src/tasks/pulse.ts
@@ -112,6 +112,13 @@ export function startPulse(jobId: string, projectId: string, pmSessionId: string
 export async function resurrectionScan(jobId: string, projectId: string): Promise<void> {
   const tasks = await Store.listTasks(projectId)
   const jobTasks = tasks.filter((t) => t.job_id === jobId)
+  
+  // Guard: only resurrect tasks if job exists and is running (prevent resurrecting deleted job's tasks)
+  const job = await Store.getJob(projectId, jobId)
+  if (!job || job.status !== "running") {
+    return
+  }
+  
   const { isPidAlive } = await import("./pulse-scheduler")
   const { sanitizeWorktree } = await import("./pulse-scheduler")
 

--- a/packages/opencode/src/tasks/store.ts
+++ b/packages/opencode/src/tasks/store.ts
@@ -294,4 +294,29 @@ export const Store = {
     jobs.sort((a, b) => time(b) - time(a))
     return jobs.find((j) => j.status === "running") ?? jobs[0]
   },
+
+  async deleteJob(projectId: string, jobId: string): Promise<void> {
+    const tasksDir = getTasksDir(projectId)
+    const jobPath = path.join(tasksDir, `job-${jobId}.json`)
+    const file = Bun.file(jobPath)
+    if (await file.exists()) {
+      await fs.unlink(jobPath).catch(() => {})
+    }
+  },
+
+  async deleteTasksByJobId(projectId: string, jobId: string): Promise<void> {
+    const tasks = await this.listTasks(projectId)
+    const matching = tasks.filter((t) => t.job_id === jobId)
+    const index = await this.getIndex(projectId)
+    for (const task of matching) {
+      await fs.unlink(getSafeTaskPath(projectId, task.id)).catch(() => {})
+      delete index[task.id]
+    }
+    await atomicWrite(path.join(getTasksDir(projectId), "index.json"), JSON.stringify(index, null, 2))
+  },
+
+  async deleteJobAndTasks(projectId: string, jobId: string): Promise<void> {
+    await this.deleteTasksByJobId(projectId, jobId)
+    await this.deleteJob(projectId, jobId)
+  },
 }


### PR DESCRIPTION
Allows taskctl start to restart a job when previous job is complete/failed/stopped — deletes old job and tasks, creates fresh. Allows taskctl resume when stopping flag is set — clears flag and proceeds. Adds deleteJob/deleteTasksByJobId/deleteJobAndTasks to Store. Fixes #293