### PR TITLE
fix: bridge permission.asked event to SSE stream so TUI SDK receives permission prompts (#298)

### DIFF
--- a/packages/opencode/src/server/event.ts
+++ b/packages/opencode/src/server/event.ts
@@ -1,7 +1,15 @@
 import { BusEvent } from "@/bus/bus-event"
+import { PermissionNext } from "@/permission/next"
 import z from "zod"
 
+export const ConnectedEvent = BusEvent.define("server.connected", z.object({}))
+export const DisposedEvent = BusEvent.define("global.disposed", z.object({}))
+
+// Lazy getter to ensure PermissionNext is loaded before accessing Event.Asked
 export const Event = {
-  Connected: BusEvent.define("server.connected", z.object({})),
-  Disposed: BusEvent.define("global.disposed", z.object({})),
+  Connected: ConnectedEvent,
+  Disposed: DisposedEvent,
+  get PermissionAsked() {
+    return PermissionNext.Event.Asked
+  },
 }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -10,10 +10,9 @@ import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
+import { DisposedEvent } from "../event"
 
 const log = Log.create({ service: "server" })
-
-export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
 
 export const GlobalRoutes = lazy(() =>
   new Hono()
@@ -173,7 +172,7 @@ export const GlobalRoutes = lazy(() =>
         GlobalBus.emit("event", {
           directory: "global",
           payload: {
-            type: GlobalDisposedEvent.type,
+            type: DisposedEvent.type,
             properties: {},
           },
         })

--- a/packages/opencode/test/server/event.test.ts
+++ b/packages/opencode/test/server/event.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { Event } from "../../src/server/event"
+import { PermissionNext } from "../../src/permission/next"
+
+describe("server/event", () => {
+  test("exports permission.asked event with correct schema", () => {
+    // Verify the PermissionAsked event exists
+    expect(Event.PermissionAsked).toBeDefined()
+
+    // Verify it references the same event object from permission/next.ts
+    expect(Event.PermissionAsked).toBe(PermissionNext.Event.Asked)
+
+    // Verify the event type is correct
+    expect(Event.PermissionAsked.type).toBe("permission.asked")
+
+    // Verify the schema has the expected structure
+    const samplePayload = {
+      id: "perm_123",
+      sessionID: "ses_456",
+      permission: "bash",
+      patterns: ["*"],
+      metadata: {},
+      always: [],
+      tool: {
+        messageID: "msg_789",
+        callID: "call_abc",
+      },
+    }
+
+    // Verify the payload can be parsed by the schema
+    const result = Event.PermissionAsked.properties.safeParse(samplePayload)
+    expect(result.success).toBe(true)
+
+    // Verify optional tool field can be omitted
+    const resultWithoutTool = Event.PermissionAsked.properties.safeParse({
+      ...samplePayload,
+      tool: undefined,
+    })
+    expect(resultWithoutTool.success).toBe(true)
+  })
+
+  test("lazy getter prevents module load order issues", () => {
+    // Access via getter multiple times to ensure it's evaluated correctly
+    const event1 = Event.PermissionAsked
+    const event2 = Event.PermissionAsked
+
+    // Both accesses should return the same object (singleton)
+    expect(event1).toBe(event2)
+    expect(event1).toBe(PermissionNext.Event.Asked)
+  })
+})


### PR DESCRIPTION
Adds PermissionAsked event to server/event.ts registry so Bus.publish(PermissionNext.Event.Asked) flows through GlobalBus to SSE stream and reaches TUI SDK. Uses lazy getter to prevent module load order race conditions. Fixes #298