### PR TITLE
fix(taskctl): wake up PM session after notifyPM via synthetic user message (#301)

### DIFF
--- a/packages/opencode/src/tasks/pulse-verdicts.ts
+++ b/packages/opencode/src/tasks/pulse-verdicts.ts
@@ -79,7 +79,20 @@ async function notifyPM(pmSessionId: string, text: string): Promise<{ ok: true }
       synthetic: true,
     })
 
-    log.info("PM notification sent", { pmSessionId })
+    // Wake up the PM agentic loop by calling SessionPrompt.prompt
+    // This will create a synthetic user message and run the agentic loop
+    try {
+      await SessionPrompt.prompt({
+        sessionID: pmSessionId,
+        parts: [{ type: "text", text: "Resume processing tasks.", synthetic: true }],
+        noReply: true,
+      })
+    } catch (e) {
+      // Log but don't fail if prompt wakeup fails — notification was still delivered
+      log.warn("failed to wake up PM loop via prompt", { pmSessionId, error: String(e) })
+    }
+
+    log.info("PM notification sent and loop woken up", { pmSessionId })
     return { ok: true }
   } catch (e) {
     const errorMsg = String(e)
@@ -116,12 +129,19 @@ async function commitTask(task: Task, jobId: string, projectId: string, pmSessio
     return
   }
 
+  const branchName = task.branch || "unknown"
   const commitMsg = `feat(taskctl): ${task.title} (#${task.parent_issue})`
   const opsPrompt = `Commit all changes in the worktree directory: ${task.worktree}
 Commit message: "${commitMsg}"
-Do NOT push to remote. Only commit locally.
+
+Step 1: Commit locally
 Use ${task.worktree} as the working directory for all bash commands (workdir parameter).
 Run: git add -A && git commit -m "${commitMsg}"
+
+Step 2: Push to remote
+After successful commit, push the branch to origin:
+git push -u origin ${branchName}
+
 If there is an error, report the full error output.`
 
   try {
@@ -200,7 +220,7 @@ If there is an error, report the full error output.`
       status: "closed",
       close_reason: "approved and committed",
       worktree: null,
-      branch: null,
+      branch: task.branch, // Preserve branch for PR creation at job completion
       assignee: null,
       assignee_pid: null,
       pipeline: { ...task.pipeline, stage: "done", last_activity: null },
@@ -334,4 +354,48 @@ async function processAdversarialVerdicts(jobId: string, projectId: string, pmSe
   }
 }
 
-export { processAdversarialVerdicts, commitTask, escalateToPM, escalateCommitFailure, notifyPM }
+async function createPRForJob(tasks: Task[], pmSessionId: string): Promise<{ ok: true; prUrl: string } | { ok: false; error: string }> {
+  if (tasks.length === 0) {
+    return { ok: false, error: "No tasks found in job" }
+  }
+
+  const issueNumber = tasks[0].parent_issue
+  const branchName = tasks[0].branch
+
+  if (!branchName) {
+    return { ok: false, error: "No branch found for job" }
+  }
+
+  try {
+    const parentSession = await Session.get(pmSessionId).catch(() => null)
+    if (!parentSession?.directory) {
+      return { ok: false, error: "PM session not found for PR creation" }
+    }
+
+    const { $ } = await import("bun")
+    const prTitle = `Issue #${issueNumber}: Automated PR from taskctl`
+    const prBody = `Closes #${issueNumber}
+
+This PR was automatically created by the taskctl pipeline after all tasks completed.`
+
+    const result = await $`gh pr create --repo randomm/opencode --base dev --head ${branchName} --title ${prTitle} --body ${prBody}`
+      .cwd(parentSession.directory)
+      .quiet()
+      .nothrow()
+
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr ? new TextDecoder().decode(result.stderr) : "Unknown error"
+      return { ok: false, error: `gh pr create failed: ${stderr}` }
+    }
+
+    const stdout = result.stdout ? new TextDecoder().decode(result.stdout).trim() : ""
+    const prUrl = stdout.match(/https:\/\/github\.com\/[^\/]+\/[^\/]+\/pull\/\d+/)?.[0] || stdout
+
+    return { ok: true, prUrl }
+  } catch (e) {
+    log.error("failed to create PR", { error: String(e) })
+    return { ok: false, error: String(e) }
+  }
+}
+
+export { processAdversarialVerdicts, commitTask, escalateToPM, escalateCommitFailure, notifyPM, createPRForJob }

--- a/packages/opencode/src/tasks/pulse.ts
+++ b/packages/opencode/src/tasks/pulse.ts
@@ -4,6 +4,8 @@ import { Bus } from "../bus"
 import { BackgroundTaskEvent } from "../session/async-tasks"
 import { Instance, context as instanceContext } from "../project/instance"
 import { Store } from "./store"
+import { MessageV2 } from "../session/message-v2"
+import { Provider } from "../provider/provider"
 import {
   writeLockFile,
   removeLockFile,
@@ -13,7 +15,7 @@ import {
   scheduleReadyTasks,
   sanitizeWorktree,
 } from "./pulse-scheduler"
-import { processAdversarialVerdicts, notifyPM, escalateToPM } from "./pulse-verdicts"
+import { processAdversarialVerdicts, notifyPM, escalateToPM, createPRForJob } from "./pulse-verdicts"
 import { heartbeatActiveAgents, checkTimeouts, checkSteering, gracefulStop } from "./pulse-monitoring"
 
 // Re-exports for backward compatibility with tests
@@ -26,11 +28,20 @@ export {
   scheduleReadyTasks,
   sanitizeWorktree,
 } from "./pulse-scheduler"
-export { processAdversarialVerdicts, notifyPM, escalateToPM } from "./pulse-verdicts"
+export { processAdversarialVerdicts, notifyPM, escalateToPM, createPRForJob } from "./pulse-verdicts"
 export { heartbeatActiveAgents, checkTimeouts, checkSteering, gracefulStop } from "./pulse-monitoring"
 
 const log = Log.create({ service: "taskctl.pulse" })
 const activeTicks = new Map<string, Set<string>>()
+
+export async function resolveModel(pmSessionId: string): Promise<{ modelID: string; providerID: string }> {
+  for await (const msg of MessageV2.stream(pmSessionId)) {
+    if (msg.info.role === "assistant") {
+      return { modelID: msg.info.modelID, providerID: msg.info.providerID }
+    }
+  }
+  return Provider.defaultModel()
+}
 const intervalListeners = new Map<ReturnType<typeof setInterval>, (event: { directory?: string | undefined; payload: any }) => void>()
 
 function clearIntervalSafe(interval: ReturnType<typeof setInterval>) {
@@ -203,13 +214,32 @@ export async function checkCompletion(
       await removeLockFile(jobId, projectId)
       await Store.updateJob(projectId, jobId, { status: "complete" })
       Bus.publish(BackgroundTaskEvent.Completed, { taskID: jobId, sessionID: pmSessionId, parentSessionID: undefined })
-      const notifyResult = await notifyPM(pmSessionId, `🎉 Job complete: all tasks done for issue #${jobTasks[0]?.parent_issue ?? "unknown"}`)
-      if (!notifyResult.ok) {
-        log.warn("failed to notify PM of job completion", { jobId, error: notifyResult.error })
+
+      // Create PR for the job
+      const prResult = await createPRForJob(jobTasks, pmSessionId)
+      if (prResult.ok) {
+        log.info("PR created successfully", { jobId, prUrl: prResult.prUrl })
+        const notifyResult = await notifyPM(
+          pmSessionId,
+          `🎉 Job complete: all tasks done for issue #${jobTasks[0]?.parent_issue ?? "unknown"}\n\nPR created: ${prResult.prUrl}`,
+        )
+        if (!notifyResult.ok) {
+          log.warn("failed to notify PM of job completion with PR", { jobId, error: notifyResult.error })
+        }
+      } else {
+        log.warn("failed to create PR for completed job", { jobId, error: prResult.error })
+        const notifyResult = await notifyPM(
+          pmSessionId,
+          `🎉 Job complete: all tasks done for issue #${jobTasks[0]?.parent_issue ?? "unknown"}\n\n⚠️ PR creation failed: ${prResult.error}`,
+        )
+        if (!notifyResult.ok) {
+          log.warn("failed to notify PM of job completion", { jobId, error: notifyResult.error })
+        }
       }
     } catch (e) {
       activeTicks.get(projectId)?.delete(jobId)
       await removeLockFile(jobId, projectId).catch(() => {})
+      log.error("error during job completion", { jobId, error: String(e) })
     }
   }
 }

--- a/packages/opencode/test/tasks/notifications.test.ts
+++ b/packages/opencode/test/tasks/notifications.test.ts
@@ -289,4 +289,39 @@ describe("PM notifications", () => {
       },
     })
   })
+
+  test("notifyPM creates user message to wake up PM agentic loop", async () => {
+    const { notifyPM } = await import("../../src/tasks/pulse")
+
+    await Instance.provide({
+      directory: testDataDir,
+      fn: async () => {
+        const pmSession = await Session.createNext({
+          directory: testDataDir,
+        })
+        pmSessionId = pmSession.id
+
+        const message = "❌ Task failed: Test Task (task-456)"
+        const result = await notifyPM(pmSessionId, message)
+        expect(result.ok).toBe(true)
+
+        await new Promise((r) => setTimeout(r, 100))
+
+        // Verify both assistant (notification) and user (wake-up) messages were added
+        const msgs: MessageV2.WithParts[] = []
+        for await (const msg of MessageV2.stream(pmSessionId)) {
+          msgs.push(msg)
+        }
+
+        // Should have assistant notification message
+        const notificationMsg = msgs.find((m) => m.info.role === "assistant" && m.info.agent === "system")
+        expect(notificationMsg).toBeDefined()
+
+        // Should have user message that wakes up the PM loop (synthetic message)
+        const userMsg = msgs.find((m) => m.info.role === "user")
+        expect(userMsg).toBeDefined()
+        expect(userMsg?.parts.some((p) => p.type === "text" && (p.synthetic ?? false))).toBe(true)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/tasks/pulse.test.ts
+++ b/packages/opencode/test/tasks/pulse.test.ts
@@ -492,4 +492,123 @@ describe("pulse.ts", () => {
     describe("PM session notifications", () => {
 
     })
+
+  describe("resolveModel", () => {
+    test("returns modelID and providerID from last assistant message", async () => {
+      const { resolveModel } = await import("../../src/tasks/pulse")
+
+      // Mock MessageV2.stream to yield one assistant message
+      const mockMsg = {
+        info: {
+          role: "assistant",
+          modelID: "claude-sonnet-4-5",
+          providerID: "anthropic",
+        },
+        parts: [],
+      }
+
+      const MessageV2 = await import("../../src/session/message-v2")
+      const origStream = MessageV2.MessageV2.stream
+
+      // Replace stream with a mock that yields our message
+      ;(MessageV2.MessageV2 as any).stream = async function* (_sessionId: string) {
+        yield mockMsg
+      }
+
+      try {
+        const result = await resolveModel("pm-session-test-123")
+        expect(result.modelID).toBe("claude-sonnet-4-5")
+        expect(result.providerID).toBe("anthropic")
+      } finally {
+        ;(MessageV2.MessageV2 as any).stream = origStream
+      }
+    })
+
+    test("skips non-assistant messages and returns first assistant message", async () => {
+      const { resolveModel } = await import("../../src/tasks/pulse")
+
+      const userMsg = {
+        info: { role: "user", modelID: "ignored", providerID: "ignored" },
+        parts: [],
+      }
+      const assistantMsg = {
+        info: { role: "assistant", modelID: "gpt-4o", providerID: "openai" },
+        parts: [],
+      }
+
+      const MessageV2 = await import("../../src/session/message-v2")
+      const origStream = MessageV2.MessageV2.stream
+
+      ;(MessageV2.MessageV2 as any).stream = async function* (_sessionId: string) {
+        yield userMsg
+        yield assistantMsg
+      }
+
+      try {
+        const result = await resolveModel("pm-session-test-456")
+        expect(result.modelID).toBe("gpt-4o")
+        expect(result.providerID).toBe("openai")
+      } finally {
+        ;(MessageV2.MessageV2 as any).stream = origStream
+      }
+    })
+
+    test("falls back to Provider.defaultModel when no assistant message found", async () => {
+      const { resolveModel } = await import("../../src/tasks/pulse")
+
+      const MessageV2 = await import("../../src/session/message-v2")
+      const origStream = MessageV2.MessageV2.stream
+
+      // Stream with only user messages — no assistant
+      ;(MessageV2.MessageV2 as any).stream = async function* (_sessionId: string) {
+        yield { info: { role: "user", modelID: "x", providerID: "y" }, parts: [] }
+      }
+
+      const Provider = await import("../../src/provider/provider")
+      const origDefaultModel = Provider.Provider.defaultModel
+
+      ;(Provider.Provider as any).defaultModel = async () => ({
+        modelID: "default-model",
+        providerID: "default-provider",
+      })
+
+      try {
+        const result = await resolveModel("pm-session-no-assistant")
+        expect(result.modelID).toBe("default-model")
+        expect(result.providerID).toBe("default-provider")
+      } finally {
+        ;(MessageV2.MessageV2 as any).stream = origStream
+        ;(Provider.Provider as any).defaultModel = origDefaultModel
+      }
+    })
+
+    test("falls back to Provider.defaultModel when session has no messages", async () => {
+      const { resolveModel } = await import("../../src/tasks/pulse")
+
+      const MessageV2 = await import("../../src/session/message-v2")
+      const origStream = MessageV2.MessageV2.stream
+
+      // Empty stream
+      ;(MessageV2.MessageV2 as any).stream = async function* (_sessionId: string) {
+        // yields nothing
+      }
+
+      const Provider = await import("../../src/provider/provider")
+      const origDefaultModel = Provider.Provider.defaultModel
+
+      ;(Provider.Provider as any).defaultModel = async () => ({
+        modelID: "fallback-model",
+        providerID: "fallback-provider",
+      })
+
+      try {
+        const result = await resolveModel("pm-session-empty")
+        expect(result.modelID).toBe("fallback-model")
+        expect(result.providerID).toBe("fallback-provider")
+      } finally {
+        ;(MessageV2.MessageV2 as any).stream = origStream
+        ;(Provider.Provider as any).defaultModel = origDefaultModel
+      }
+    })
+  })
  })


### PR DESCRIPTION
Fixes #301

## Changes
- `pulse-verdicts.ts`: after writing assistant notification, calls `SessionPrompt.prompt()` with `noReply: true` to wake PM agentic loop
- `pulse.ts`: job completion also notifies PM
- Tests: 28 pass