### PR TITLE
fix(taskctl): move tasks data directory inside project at .opencode/tasks/ (#307)

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -3,3 +3,4 @@ dist
 gen
 app.log
 src/provider/models-snapshot.ts
+.opencode/tasks/

--- a/packages/opencode/src/tasks/pulse-scheduler.ts
+++ b/packages/opencode/src/tasks/pulse-scheduler.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import { $ } from "bun"
 import { Session } from "../session"
@@ -26,6 +27,11 @@ async function lockFilePath(jobId: string, projectId: string): Promise<string> {
   } catch {
     // Fallback for tests without Instance context
     tasksDir = path.join(Global.Path.data, "tasks", projectId)
+  }
+
+  // Safe fallback: if path resolves to /.opencode or /, use tmpdir
+  if (tasksDir.startsWith("/.opencode") || tasksDir === "/") {
+    tasksDir = path.join(os.tmpdir(), "opencode-tasks-test", projectId)
   }
 
   await fs.mkdir(tasksDir, { recursive: true })

--- a/packages/opencode/src/tasks/pulse-scheduler.ts
+++ b/packages/opencode/src/tasks/pulse-scheduler.ts
@@ -19,7 +19,15 @@ import { MAX_ADVERSARIAL_ATTEMPTS } from "./pulse-verdicts"
 const log = Log.create({ service: "taskctl.pulse.scheduler" })
 
 async function lockFilePath(jobId: string, projectId: string): Promise<string> {
-  const tasksDir = path.join(Global.Path.data, "tasks", projectId)
+  let tasksDir: string
+  try {
+    const worktree = Instance.worktree
+    tasksDir = path.join(worktree, ".opencode", "tasks", projectId)
+  } catch {
+    // Fallback for tests without Instance context
+    tasksDir = path.join(Global.Path.data, "tasks", projectId)
+  }
+
   await fs.mkdir(tasksDir, { recursive: true })
 
   const files = await fs.readdir(tasksDir)

--- a/packages/opencode/src/tasks/store.ts
+++ b/packages/opencode/src/tasks/store.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises"
+import os from "os"
 import path from "path"
 import { Instance } from "../project/instance"
 import { Global } from "../global/index"
@@ -41,13 +42,21 @@ function sanitizeTaskId(taskId: string): string {
 
 function getTasksDir(projectId: string): string {
   const sanitized = sanitizeProjectId(projectId)
+  let tasksDir: string
   try {
     const worktree = Instance.worktree
-    return path.join(worktree, ".opencode", TASKS_DIR_NAME, sanitized)
+    tasksDir = path.join(worktree, ".opencode", TASKS_DIR_NAME, sanitized)
   } catch {
     // Fallback for tests without Instance context
-    return path.join(Global.Path.data, TASKS_DIR_NAME, sanitized)
+    tasksDir = path.join(Global.Path.data, TASKS_DIR_NAME, sanitized)
   }
+
+  // Safe fallback: if path resolves to /.opencode or /, use tmpdir
+  if (tasksDir.startsWith("/.opencode") || tasksDir === "/") {
+    return path.join(os.tmpdir(), "opencode-tasks-test", sanitized)
+  }
+
+  return tasksDir
 }
 
 function getSafeTaskPath(projectId: string, taskId: string): string {

--- a/packages/opencode/src/tasks/store.ts
+++ b/packages/opencode/src/tasks/store.ts
@@ -1,9 +1,11 @@
 import fs from "fs/promises"
 import path from "path"
+import { Instance } from "../project/instance"
 import { Global } from "../global/index"
+import { Context } from "../util/context"
 import type { Task, Job, TaskIndex, Comment, PipelineEvent } from "./types"
 
-const TASKS_DIR = "tasks"
+const TASKS_DIR_NAME = "tasks"
 
 function sanitizeProjectId(projectId: string): string {
   if (!projectId || typeof projectId !== "string") {
@@ -39,7 +41,13 @@ function sanitizeTaskId(taskId: string): string {
 
 function getTasksDir(projectId: string): string {
   const sanitized = sanitizeProjectId(projectId)
-  return path.join(Global.Path.data, TASKS_DIR, sanitized)
+  try {
+    const worktree = Instance.worktree
+    return path.join(worktree, ".opencode", TASKS_DIR_NAME, sanitized)
+  } catch {
+    // Fallback for tests without Instance context
+    return path.join(Global.Path.data, TASKS_DIR_NAME, sanitized)
+  }
 }
 
 function getSafeTaskPath(projectId: string, taskId: string): string {

--- a/packages/opencode/test/tasks/notifications.test.ts
+++ b/packages/opencode/test/tasks/notifications.test.ts
@@ -28,8 +28,7 @@ describe("PM notifications", () => {
   })
 
   afterEach(async () => {
-    const tasksDir = path.join(Global.Path.data, "tasks", TEST_PROJECT_ID)
-    const lockPath = path.join(tasksDir, `job-${TEST_JOB_ID}.lock`)
+    const lockPath = path.join(Global.Path.data, "tasks", TEST_PROJECT_ID, `job-${TEST_JOB_ID}.lock`)
     await fs.unlink(lockPath).catch(() => {})
 
     await fs.rm(testDataDir, { recursive: true, force: true }).catch(() => {})

--- a/packages/opencode/test/tasks/pulse.test.ts
+++ b/packages/opencode/test/tasks/pulse.test.ts
@@ -24,8 +24,7 @@ describe("pulse.ts", () => {
   })
 
   afterEach(async () => {
-    const tasksDir = path.join(Global.Path.data, "tasks", TEST_PROJECT_ID)
-    const lockPath = path.join(tasksDir, `job-${TEST_JOB_ID}.lock`)
+    const lockPath = path.join(Global.Path.data, "tasks", TEST_PROJECT_ID, `job-${TEST_JOB_ID}.lock`)
     await fs.unlink(lockPath).catch(() => {})
 
     await fs.rm(testDataDir, { recursive: true, force: true }).catch(() => {})


### PR DESCRIPTION
Fixes #307

## Changes
- store.ts: getTasksDir() returns project-root/.opencode/tasks/ instead of ~/.local/share/
- pulse-scheduler.ts: lock file path updated
- .gitignore: .opencode/tasks/ added
- Tests updated