### PR TITLE
fix(hashline): rename hashline_edit parameter 'file' to 'filePath' for consistency

### DIFF
--- a/packages/opencode/src/tool/hashline_edit.ts
+++ b/packages/opencode/src/tool/hashline_edit.ts
@@ -10,7 +10,7 @@ import { applyHashlineEdits, type HashlineEdit, parseAnchor } from "./hashline"
 export const HashlineEditTool = Tool.define("hashline_edit", {
   description: DESCRIPTION,
   parameters: z.object({
-    file: z.string().describe("Absolute path to the file to edit"),
+    filePath: z.string().describe("Absolute path to the file to edit"),
     edits: z
       .array(
         z.discriminatedUnion("op", [
@@ -36,7 +36,7 @@ export const HashlineEditTool = Tool.define("hashline_edit", {
       .describe("List of edits to apply atomically"),
   }),
   async execute(params, ctx) {
-    const filepath = path.isAbsolute(params.file) ? params.file : path.join(Instance.directory, params.file)
+    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
 
     await assertExternalDirectory(ctx, filepath)
 
@@ -79,7 +79,7 @@ export const HashlineEditTool = Tool.define("hashline_edit", {
 
     return {
       title: path.relative(Instance.worktree, filepath),
-      output: `Edit applied successfully to ${params.file}`,
+      output: `Edit applied successfully to ${params.filePath}`,
       metadata: {},
     }
   },

--- a/packages/opencode/test/tool/hashline_edit.test.ts
+++ b/packages/opencode/test/tool/hashline_edit.test.ts
@@ -31,7 +31,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [{ op: "set_line", anchor: "2咲", new_text: "new line 2" }],
           },
           ctx
@@ -56,7 +56,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [{ op: "set_line", anchor: "2咲", new_text: "" }],
           },
           ctx
@@ -81,7 +81,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [
               {
                 op: "replace_lines",
@@ -113,7 +113,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [
               {
                 op: "replace_lines",
@@ -145,7 +145,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [
               {
                 op: "insert_after",
@@ -176,7 +176,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [{ op: "set_line", anchor: "2戌", new_text: "new line" }],
           },
           ctx
@@ -202,7 +202,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [{ op: "set_line", anchor: "2咲", new_text: "line2" }],
           },
           ctx
@@ -227,7 +227,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [
               { op: "set_line", anchor: "2咲", new_text: "updated line 2" },
               { op: "set_line", anchor: "3徃", new_text: "updated line 3" },
@@ -255,7 +255,7 @@ describe("tool.hashline_edit", () => {
         FileTime.read(ctx.sessionID, path.join(tmp.path, "test.txt"))
         const result = await tool.execute(
           {
-            file: path.join(tmp.path, "test.txt"),
+            filePath: path.join(tmp.path, "test.txt"),
             edits: [
               { op: "set_line", anchor: "2咲", new_text: "this should apply" },
               { op: "set_line", anchor: "3戌", new_text: "this should fail" },


### PR DESCRIPTION
Renames the `file` parameter in `hashline_edit` to `filePath` to match `hashline_read` and all other file tools. Agents were calling `hashline_edit` with `filePath=` (matching hashline_read), getting a schema error, then retrying with `file=`. This eliminates that confusion.

Fixes #312