### PR TITLE
fix(taskctl): resolve model from PM session in all spawn functions

### DIFF
--- a/packages/opencode/src/tasks/pulse-monitoring.ts
+++ b/packages/opencode/src/tasks/pulse-monitoring.ts
@@ -5,6 +5,7 @@ import { Log } from "../util/log"
 import { Store } from "./store"
 import { sanitizeWorktree, isSessionActivelyRunning, isPidAlive, removeLockFile } from "./pulse-scheduler"
 import type { Task } from "./types"
+import { resolveModel } from "./pulse"
 
 const log = Log.create({ service: "taskctl.pulse.monitoring" })
 
@@ -190,10 +191,12 @@ ${history}
 
 Assess the developer's progress and respond with the appropriate JSON action.`
 
+  const model = await resolveModel(pmSessionId)
   try {
     await SessionPrompt.prompt({
       sessionID: steeringSession.id,
       agent: "steering",
+      model,
       parts: [{ type: "text", text: prompt }],
     })
   } catch (e) {
@@ -230,7 +233,7 @@ Assess the developer's progress and respond with the appropriate JSON action.`
     return { action: "continue", message: null }
   }
 
-  const responseText = textParts.map((p) => (p as any).text).join("\n")
+  const responseText = textParts.map((p) => p.text).join("\n")
 
   let response
   try {
@@ -295,9 +298,11 @@ export async function checkSteering(jobId: string, projectId: string, pmSessionI
       if (task.assignee) {
         const sessionId = task.assignee
         try {
+          const model = await resolveModel(pmSessionId)
           await SessionPrompt.prompt({
             sessionID: sessionId,
             agent: "developer-pipeline",
+            model,
             parts: [{ type: "text", text: `[Steering guidance]: ${result.message}` }],
           })
         } catch (e) {

--- a/packages/opencode/src/tasks/pulse-scheduler.ts
+++ b/packages/opencode/src/tasks/pulse-scheduler.ts
@@ -16,6 +16,7 @@ import { Global } from "../global"
 import { Instance as InstanceImport } from "../project/instance"
 import type { Task, AdversarialVerdict } from "./types"
 import { MAX_ADVERSARIAL_ATTEMPTS } from "./pulse-verdicts"
+import { resolveModel } from "./pulse"
 
 const log = Log.create({ service: "taskctl.pulse.scheduler" })
 
@@ -228,11 +229,13 @@ async function spawnDeveloper(task: Task, jobId: string, projectId: string, pmSe
     true,
   )
 
+  const model = await resolveModel(pmSessionId)
   const prompt = buildDeveloperPrompt(task)
   try {
     await SessionPrompt.prompt({
       sessionID: devSession.id,
       agent: "developer-pipeline",
+      model,
       parts: [{ type: "text", text: prompt }],
     })
   } catch (e) {
@@ -344,12 +347,14 @@ git diff ${task.base_commit || "dev"}..HEAD
 
 This ensures you only review changes made by the developer, not commits that were already in dev.
 
-Read the changed files in the worktree, run typecheck, and record your verdict with taskctl verdict.`
+  Read the changed files in the worktree, run typecheck, and record your verdict with taskctl verdict.`
 
+  const model = await resolveModel(pmSessionId)
   try {
     await SessionPrompt.prompt({
       sessionID: adversarialSession.id,
       agent: "adversarial-pipeline",
+      model,
       parts: [{ type: "text", text: prompt }],
     })
   } catch (e) {
@@ -451,12 +456,14 @@ Summary: ${verdict.summary}
 Issues:
 ${issueLines}
 
-The codebase changes are already in this worktree. Fix the specific issues listed above, run tests, and complete your work. The pulse system automatically detects completion.`
+  The codebase changes are already in this worktree. Fix the specific issues listed above, run tests, and complete your work. The pulse system automatically detects completion.`
 
+  const model = await resolveModel(pmSessionId)
   try {
     await SessionPrompt.prompt({
       sessionID: devSession.id,
       agent: "developer-pipeline",
+      model,
       parts: [{ type: "text", text: prompt }],
     })
   } catch (e) {


### PR DESCRIPTION
Fixes the "prefill not supported" error by resolving the model from the PM session and passing it to `SessionPrompt.prompt()` in all spawn functions: `spawnDeveloper`, `spawnAdversarial`, `respawnDeveloper` (pulse-scheduler.ts) and `spawnSteering`, `checkSteering` guidance (pulse-monitoring.ts).

Fixes #262