### PR TITLE
fix(tasks): raise concurrent task limit from 5 to 10

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -9,7 +9,7 @@
   "features": {
     "async-tasks": {
       "status": "active",
-      "description": "Background task execution with slot-based concurrency (max 5). Supports both async and sync modes. Enables agent orchestration via /task and /check_task tools.",
+      "description": "Background task execution with slot-based concurrency (max 10). Supports both async and sync modes. Enables agent orchestration via /task and /check_task tools.",
       "issue": "https://github.com/randomm/opencode/issues/159",
       "newFiles": [
         "packages/opencode/src/session/async-tasks.ts",
@@ -48,7 +48,8 @@
         "triggerWakeup",
         "autoWakeupSubscribers",
         "hasUndeliveredCompletedTasks",
-        "getAndClearCompletedTasks"
+        "getAndClearCompletedTasks",
+        "MAX_CONCURRENT_TASKS_PER_SESSION = 10"
       ],
       "tests": [
         "packages/opencode/test/tool/check_task.test.ts",

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -31,7 +31,7 @@ const parameters = z.object({
   sync: z.boolean().describe("Execute synchronously and wait for result").optional(),
 })
 
-const MAX_CONCURRENT_TASKS_PER_SESSION = 5
+const MAX_CONCURRENT_TASKS_PER_SESSION = 10
 
 type LockCallback = (release: () => void) => void
 interface LockState {


### PR DESCRIPTION
Raises MAX_CONCURRENT_TASKS_PER_SESSION from 5 to 10 to match AGENTS.md documented limit. Updates .fork-features/manifest.json async-tasks description and criticalCode array to anchor the new value against future upstream syncs.

Fixes #330