### PR TITLE
fix(tasks): fix off-by-one in post-reserve guard

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -87,7 +87,7 @@ export async function tryIncrementSessionCount(
     const releaseSlot = reserveTaskSlot(sessionID)
 
     const afterReserve = getSessionTaskCount(sessionID)
-    if (afterReserve > MAX_CONCURRENT_TASKS_PER_SESSION) {
+    if (afterReserve >= MAX_CONCURRENT_TASKS_PER_SESSION) {
       releaseSlot()
       return { allowed: false }
     }


### PR DESCRIPTION
Fixes #331

Change post-reserve guard from `>` to `>=` to be consistent with the pre-check on line 85. Without this, a count of exactly MAX would pass the guard after reservation.