### PR TITLE
fix(hashline): update hashlineRead timestamp after write (#348)

### DIFF
--- a/packages/opencode/src/tool/hashline_edit.ts
+++ b/packages/opencode/src/tool/hashline_edit.ts
@@ -122,7 +122,7 @@ export const HashlineEditTool = Tool.define("hashline_edit", {
       const contentOld = await file.text()
       const contentNew = applyHashlineEdits(contentOld, parsedEdits)
       await Bun.write(filepath, contentNew)
-      FileTime.read(ctx.sessionID, filepath)
+      FileTime.hashlineRead(ctx.sessionID, filepath)
     })
 
     return {

--- a/packages/opencode/test/tool/hashline_edit.test.ts
+++ b/packages/opencode/test/tool/hashline_edit.test.ts
@@ -561,4 +561,47 @@ describe("tool.hashline_edit", () => {
       },
     })
   })
+
+  test("consecutive hashline_edit calls work without re-reading in between", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "test.txt"), "line1\nline2\nline3\nline4")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await HashlineEditTool.init()
+        const filepath = path.join(tmp.path, "test.txt")
+
+        // First: hashline_read the file
+        FileTime.hashlineRead(ctx.sessionID, filepath)
+
+        // Second: do first edit
+        const result1 = await tool.execute(
+          {
+            filePath: filepath,
+            edits: [{ op: "set_line", anchor: "2咲", new_text: "edited line 2" }],
+          },
+          ctx
+        )
+        expect(result1.output).toContain("Edit applied successfully")
+
+        // Third: do second edit WITHOUT re-reading - this should succeed
+        // because hashline_edit now correctly updates the hashlineRead timestamp
+        const result2 = await tool.execute(
+          {
+            filePath: filepath,
+            edits: [{ op: "set_line", anchor: "3徃", new_text: "edited line 3" }],
+          },
+          ctx
+        )
+        expect(result2.output).toContain("Edit applied successfully")
+
+        // Verify both edits were applied
+        const content = await Bun.file(filepath).text()
+        expect(content).toBe("line1\nedited line 2\nedited line 3\nline4")
+      },
+    })
+  })
 })


### PR DESCRIPTION
Fixes hashline_edit calling FileTime.read() instead of FileTime.hashlineRead() after writing the file.

This was causing agents to hit "file modified since last read" errors after every edit, forcing unnecessary re-reads.

Added test: consecutive hashline_edit calls now work without re-reading in between.

Fixes #348