### PR TITLE
perf(session): cache messages in loop() to avoid full DB re-scan per message (#362)

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -297,6 +297,40 @@
         ]
       }
     },
+    "loop-message-cache": {
+      "status": "active",
+      "description": "Caches session messages in loop() to avoid full DB re-scan on every while(true) iteration. Before the loop, messages are fetched once with filterCompacted(). Each subsequent iteration appends only new messages via MessageV2.streamAfter() (a new cursor-based DB query using gt(MessageTable.id, afterID)). Full re-fetch is triggered only when compaction boundary changes (compaction, context overflow, or compact result). insertReminders is protected from mutating the cache by passing a shallow copy of msgs. Eliminates 5-15s blocking per message in long sessions.",
+      "issue": "https://github.com/randomm/opencode/issues/362",
+      "newFiles": [],
+      "deletedFiles": [],
+      "modifiedFiles": [
+        "packages/opencode/src/session/prompt.ts",
+        "packages/opencode/src/session/message-v2.ts"
+      ],
+      "criticalCode": [
+        "needsFullRefresh",
+        "MessageV2.streamAfter",
+        "streamAfter",
+        "gt(MessageTable.id, afterID)",
+        "msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))",
+        "const newMsgs = await MessageV2.streamAfter(sessionID",
+        "msgsForLLM",
+        "msgs.map((m) => ({ ...m, parts: [...m.parts] }))"
+      ],
+      "tests": [
+        "packages/opencode/test/session/message-v2.test.ts",
+        "packages/opencode/test/session/compaction.test.ts"
+      ],
+      "upstreamTracking": {
+        "absorptionSignals": [
+          "streamAfter",
+          "needsFullRefresh",
+          "loop.*message.*cache",
+          "filterCompacted.*cache",
+          "msgs.*incremental"
+        ]
+      }
+    },
     "taskctl": {
       "status": "active",
       "description": "Autonomous pipeline for managing task graphs with dependencies, priority ordering, conflict detection, and adversarial workflow. Phase 1 includes types, store, scheduler, validation, and CLI tool. Phase 2 adds Composer agent for automatic issue decomposition, taskctl start command for spawning full pipeline. Phase 3 adds Pulse execution engine with heartbeat, scheduling, singleton lock, crash recovery, and timeout detection. Phase 3a adds adversarial workflow integration with pipeline stages (developing, reviewing, adversarial, steering), verdict tracking, and auto-retry logic. Phase 3b adds agent.ts integration for spawning adversarial sessions (developer-pipeline and adversarial-pipeline agent definitions). Phase 3c adds PM control commands: status, stop, resume, override, retry, inspect for manual pipeline intervention. Phase 4 adds self-healing steering agent (evaluates progress every 15 min, sends guidance or replaces developer), improved adversarial timeout detection (60 min), and session message retrieval for activity summaries. Phase 5 updates AGENTS.md with taskctl documentation section describing pipeline workflow and PM commands.",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -6,7 +6,7 @@ import { Identifier } from "../id/id"
 import { LSP } from "../lsp"
 import { Snapshot } from "@/snapshot"
 import { fn } from "@/util/fn"
-import { Database, eq, desc, inArray } from "@/storage/db"
+import { Database, eq, desc, inArray, gt, and, asc } from "@/storage/db"
 import { MessageTable, PartTable } from "./session.sql"
 import { ProviderTransform } from "@/provider/transform"
 import { STATUS_CODES } from "http"
@@ -765,6 +765,50 @@ export namespace MessageV2 {
       if (rows.length < size) break
     }
   })
+
+  /**
+   * Fetch messages for a session that were created after `afterID` (exclusive),
+   * returned in ascending chronological order. Used for incremental cache updates
+   * in the loop() to avoid full DB re-scans on every iteration.
+   */
+  export async function streamAfter(sessionID: string, afterID: string): Promise<MessageV2.WithParts[]> {
+    const rows = Database.use((db) =>
+      db
+        .select()
+        .from(MessageTable)
+        .where(and(eq(MessageTable.session_id, sessionID), gt(MessageTable.id, afterID)))
+        .orderBy(asc(MessageTable.id))
+        .all(),
+    )
+    if (rows.length === 0) return []
+
+    const ids = rows.map((row) => row.id)
+    const partsByMessage = new Map<string, MessageV2.Part[]>()
+    const partRows = Database.use((db) =>
+      db
+        .select()
+        .from(PartTable)
+        .where(inArray(PartTable.message_id, ids))
+        .orderBy(PartTable.message_id, PartTable.id)
+        .all(),
+    )
+    for (const row of partRows) {
+      const part = {
+        ...row.data,
+        id: row.id,
+        sessionID: row.session_id,
+        messageID: row.message_id,
+      } as MessageV2.Part
+      const list = partsByMessage.get(row.message_id)
+      if (list) list.push(part)
+      else partsByMessage.set(row.message_id, [part])
+    }
+
+    return rows.map((row) => ({
+      info: { ...row.data, id: row.id, sessionID: row.session_id } as MessageV2.Info,
+      parts: partsByMessage.get(row.id) ?? [],
+    }))
+  }
 
   export const parts = fn(Identifier.schema("message"), async (message_id) => {
     const rows = Database.use((db) =>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -47,8 +47,7 @@ import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
 
-// @ts-ignore
-globalThis.AI_SDK_LOG_WARNINGS = false
+;(globalThis as unknown as { AI_SDK_LOG_WARNINGS: boolean }).AI_SDK_LOG_WARNINGS = false
 
 const STRUCTURED_OUTPUT_DESCRIPTION = `Use this tool to return your final response in the requested structured format.
 
@@ -299,11 +298,28 @@ export namespace SessionPrompt {
 
     let step = 0
     const session = await Session.get(sessionID)
+
+    // Initial full fetch — cached across iterations to avoid full DB re-scan every loop.
+    // Incremental updates append only new messages using streamAfter().
+    // Set needsFullRefresh=true before any `continue` that may change the compaction
+    // boundary (compaction) or write to existing message parts (subtask).
+    let msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+    let needsFullRefresh = false
+
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
       log.info("loop", { step, sessionID })
       if (abort.aborted) break
-      let msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+
+      // Refresh message cache: full re-fetch when compaction changed the boundary,
+      // otherwise append only messages written since last iteration.
+      if (needsFullRefresh) {
+        msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+        needsFullRefresh = false
+      } else if (msgs.length > 0) {
+        const newMsgs = await MessageV2.streamAfter(sessionID, msgs[msgs.length - 1].info.id)
+        if (newMsgs.length > 0) msgs = [...msgs, ...newMsgs]
+      }
 
       let lastUser: MessageV2.User | undefined
       let lastAssistant: MessageV2.Assistant | undefined
@@ -530,6 +546,8 @@ export namespace SessionPrompt {
           } satisfies MessageV2.TextPart)
         }
 
+        // Subtask writes to existing messages in complex ways; full re-fetch next iteration.
+        needsFullRefresh = true
         continue
       }
 
@@ -543,6 +561,8 @@ export namespace SessionPrompt {
           auto: task.auto,
         })
         if (result === "stop") break
+        // Compaction changes the boundary; must re-fetch to apply filterCompacted correctly.
+        needsFullRefresh = true
         continue
       }
 
@@ -558,6 +578,8 @@ export namespace SessionPrompt {
           model: lastUser.model,
           auto: true,
         })
+        // Compaction changes the boundary; must re-fetch to apply filterCompacted correctly.
+        needsFullRefresh = true
         continue
       }
 
@@ -565,11 +587,19 @@ export namespace SessionPrompt {
       const agent = await Agent.get(lastUser.agent)
       const maxSteps = agent.steps ?? Infinity
       const isLastStep = step >= maxSteps
-      msgs = await insertReminders({
-        messages: msgs,
+
+      // insertReminders may push ephemeral in-memory parts onto message objects.
+      // Use a shallow copy (with copied parts arrays) so the cached `msgs` is not mutated
+      // and those synthetic parts don't accumulate across iterations.
+      const reminders = await insertReminders({
+        messages: msgs.map((m) => ({ ...m, parts: [...m.parts] })),
         agent,
         session,
       })
+      const msgsForLLM = reminders.messages
+      // insertReminders may write parts to the DB (e.g. plan-mode system reminder).
+      // Mark for full refresh so streamAfter doesn't miss those written parts next iteration.
+      if (reminders.wroteToDb) needsFullRefresh = true
 
       const processor = SessionProcessor.create({
         assistantMessage: (await Session.updateMessage({
@@ -604,7 +634,7 @@ export namespace SessionPrompt {
       using _ = defer(() => InstructionPrompt.clear(processor.message.id))
 
       // Check if user explicitly invoked an agent via @ in this turn
-      const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
+      const lastUserMsg = msgsForLLM.findLast((m) => m.info.role === "user")
       const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
       const tools = await resolveTools({
@@ -614,7 +644,7 @@ export namespace SessionPrompt {
         tools: lastUser.tools,
         processor,
         bypassAgentCheck,
-        messages: msgs,
+        messages: msgsForLLM,
       })
 
       // Inject StructuredOutput tool if JSON schema mode enabled
@@ -634,7 +664,7 @@ export namespace SessionPrompt {
         })
       }
 
-      const sessionMessages = clone(msgs)
+      const sessionMessages = clone(msgsForLLM)
 
       // Ephemerally wrap queued user messages with a reminder to stay on track
       if (step > 1 && lastFinished) {
@@ -718,6 +748,8 @@ export namespace SessionPrompt {
           model: lastUser.model,
           auto: true,
         })
+        // Compaction changes the boundary; must re-fetch to apply filterCompacted correctly.
+        needsFullRefresh = true
       }
       continue
     }
@@ -1326,9 +1358,13 @@ export namespace SessionPrompt {
     }
   }
 
-  async function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info; session: Session.Info }) {
+  async function insertReminders(input: {
+    messages: MessageV2.WithParts[]
+    agent: Agent.Info
+    session: Session.Info
+  }): Promise<{ messages: MessageV2.WithParts[]; wroteToDb: boolean }> {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
-    if (!userMessage) return input.messages
+    if (!userMessage) return { messages: input.messages, wroteToDb: false }
 
     // Original logic when experimental plan mode is disabled
     if (!Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE) {
@@ -1353,7 +1389,7 @@ export namespace SessionPrompt {
           synthetic: true,
         })
       }
-      return input.messages
+      return { messages: input.messages, wroteToDb: false }
     }
 
     // New plan mode logic when flag is enabled
@@ -1374,8 +1410,9 @@ export namespace SessionPrompt {
           synthetic: true,
         })
         userMessage.parts.push(part)
+        return { messages: input.messages, wroteToDb: true }
       }
-      return input.messages
+      return { messages: input.messages, wroteToDb: false }
     }
 
     // Entering plan mode
@@ -1461,9 +1498,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         synthetic: true,
       })
       userMessage.parts.push(part)
-      return input.messages
+      return { messages: input.messages, wroteToDb: true }
     }
-    return input.messages
+    return { messages: input.messages, wroteToDb: false }
   }
 
   export const ShellInput = z.object({


### PR DESCRIPTION
## Summary

- loop() in session/prompt.ts was calling MessageV2.filterCompacted(MessageV2.stream(sessionID)) on every iteration, doing a full paginated SQLite scan of all session messages each time a message is processed
- In long sessions this caused 5-15s of blocking per message (pre-existing issue, not fixed upstream)
- Fix: fetch messages once before the loop, then use new MessageV2.streamAfter(sessionID, afterID) to append only new messages on each iteration
- Full re-fetch triggered only when compaction boundary changes or plan-mode writes to DB
- insertReminders refactored to return { messages, wroteToDb } so the cache knows when to invalidate
- Also removes pre-existing @ts-ignore on line 50

Fixes #362