### PR TITLE
fix(provider): extend error schema to handle status_code-wrapped error responses

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -490,31 +490,43 @@
       }
     },
     "openai-compatible-choices-validation": {
-      "status": "active",
-      "description": "Guards doGenerate and doStream against missing/empty choices array in OpenAI-compatible provider responses. Throws InvalidResponseDataError with raw payload context instead of propagating AI_TypeValidationError (invalid_union).",
-      "issue": "https://github.com/randomm/opencode/issues/365",
-      "newFiles": [],
-      "modifiedFiles": [
-        "packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts"
-      ],
-      "criticalCode": [
-        "InvalidResponseDataError",
-        "responseBody.choices?.length",
-        "value.choices?.length",
-        "OpenAI-compatible provider returned no choices"
-      ],
-      "tests": [
-        "packages/opencode/test/provider/copilot/copilot-chat-model.test.ts"
-      ],
-      "upstreamTracking": {
-        "absorptionSignals": [
-          "responseBody.choices?.length",
-          "value.choices?.length",
-          "InvalidResponseDataError.*choices",
-          "choices.*length.*0",
-          "no choices.*provider"
-        ]
-       }
-     }
+       "status": "active",
+       "description": "Guards OpenAI-compatible provider responses against validation errors. (1) Issue #365: Prevents AI_TypeValidationError when choices array is missing/empty by throwing InvalidResponseDataError instead. (2) Issue #367: Normalizes error response schema to accept both standard OpenAI format and status_code-wrapped format, supporting providers with different error response structures.",
+       "issue": "https://github.com/randomm/opencode/issues/367",
+       "newFiles": [],
+       "modifiedFiles": [
+         "packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts",
+         "packages/opencode/src/provider/sdk/copilot/openai-compatible-error.ts"
+       ],
+       "criticalCode": [
+         "InvalidResponseDataError",
+         "responseBody.choices?.length",
+         "value.choices?.length",
+         "OpenAI-compatible provider returned no choices",
+         "status_code",
+         "openaiCompatibleErrorDataSchema",
+         "errorToMessage",
+         "standardErrorObject",
+         "wrappedErrorObject",
+         "Both union branches have error.message at the same path"
+       ],
+       "tests": [
+         "packages/opencode/test/provider/copilot/copilot-chat-model.test.ts",
+         "packages/opencode/test/provider/copilot/openai-compatible-error.test.ts"
+       ],
+       "upstreamTracking": {
+         "absorptionSignals": [
+           "responseBody.choices?.length",
+           "value.choices?.length",
+           "InvalidResponseDataError.*choices",
+           "choices.*length.*0",
+           "no choices.*provider",
+           "status_code.*error",
+           "openaiCompatibleErrorDataSchema.*union",
+           "wrappedErrorObject",
+           "standardErrorObject"
+         ]
+        }
+      }
    }
  }

--- a/packages/opencode/src/provider/sdk/copilot/openai-compatible-error.ts
+++ b/packages/opencode/src/provider/sdk/copilot/openai-compatible-error.ts
@@ -1,6 +1,6 @@
 import { z, type ZodType } from "zod/v4"
 
-export const openaiCompatibleErrorDataSchema = z.object({
+const standardErrorObject = z.object({
   error: z.object({
     message: z.string(),
 
@@ -10,8 +10,24 @@ export const openaiCompatibleErrorDataSchema = z.object({
     type: z.string().nullish(),
     param: z.any().nullish(),
     code: z.union([z.string(), z.number()]).nullish(),
-  }),
+  }).passthrough(),
+}).strict()
+
+const wrappedErrorObject = z.object({
+  status_code: z.number(),
+  error: z.object({
+    message: z.string(),
+    type: z.string().nullish(),
+    param: z.any().nullish(),
+    code: z.union([z.string(), z.number()]).nullish(),
+    id: z.string().nullish(),
+  }).passthrough(),
 })
+
+export const openaiCompatibleErrorDataSchema = z.union([
+  standardErrorObject,
+  wrappedErrorObject,
+])
 
 export type OpenAICompatibleErrorData = z.infer<typeof openaiCompatibleErrorDataSchema>
 

--- a/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
@@ -1,0 +1,251 @@
+import { describe, test, expect } from "bun:test"
+import {
+  openaiCompatibleErrorDataSchema,
+  defaultOpenAICompatibleErrorStructure,
+  type OpenAICompatibleErrorData,
+} from "@/provider/sdk/copilot/openai-compatible-error"
+import { z } from "zod/v4"
+
+describe("openaiCompatibleErrorDataSchema", () => {
+  test("accepts standard OpenAI error format", () => {
+    const data = {
+      error: {
+        message: "Invalid request",
+        type: "invalid_request_error",
+        param: "messages",
+        code: "invalid_input",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.error.message).toBe("Invalid request")
+    }
+  })
+
+  test("accepts standard OpenAI error with optional fields as null", () => {
+    const data = {
+      error: {
+        message: "Server error",
+        type: null,
+        param: null,
+        code: null,
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.error.message).toBe("Server error")
+    }
+  })
+
+  test("accepts status_code-wrapped error format", () => {
+    const data = {
+      status_code: 500,
+      error: {
+        message: "Internal server error",
+        type: "server_error",
+        param: "",
+        code: "",
+        id: "err-123",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.error.message).toBe("Internal server error")
+    }
+  })
+
+  test("accepts status_code-wrapped format with optional fields as null", () => {
+    const data = {
+      status_code: 503,
+      error: {
+        message: "Service unavailable",
+        type: null,
+        param: null,
+        code: null,
+        id: null,
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.error.message).toBe("Service unavailable")
+    }
+  })
+
+  test("accepts code as number in standard format", () => {
+    const data = {
+      error: {
+        message: "Rate limit exceeded",
+        type: "rate_limit_error",
+        param: null,
+        code: 429,
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts code as number in status_code-wrapped format", () => {
+    const data = {
+      status_code: 500,
+      error: {
+        message: "Error",
+        type: "server_error",
+        param: "",
+        code: 5000,
+        id: "",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  test("allows extra unknown fields in error object", () => {
+    const data = {
+      error: {
+        message: "Invalid request",
+        type: "invalid_request_error",
+        param: null,
+        code: null,
+        timestamp: "2024-01-01T00:00:00Z",
+        request_id: "req-abc123",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  test("allows extra unknown fields in status_code-wrapped format", () => {
+    const data = {
+      status_code: 500,
+      error: {
+        message: "Internal server error",
+        type: "server_error",
+        param: "",
+        code: "",
+        id: "err-123",
+        trace_id: "trace-456",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects missing message field", () => {
+    const data = {
+      error: {
+        type: "invalid_request_error",
+      },
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects error object missing entirely", () => {
+    const data = {
+      status: "error",
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects neither standard nor wrapped format", () => {
+    const data = {
+      errorMessage: "Something went wrong",
+    }
+
+    const result = openaiCompatibleErrorDataSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+
+  test("accepts param as any type in standard format", () => {
+    const data1 = {
+      error: {
+        message: "Error",
+        type: "error",
+        param: "string_param",
+        code: null,
+      },
+    }
+    const data2 = {
+      error: {
+        message: "Error",
+        type: "error",
+        param: 42,
+        code: null,
+      },
+    }
+    const data3 = {
+      error: {
+        message: "Error",
+        type: "error",
+        param: { nested: "object" },
+        code: null,
+      },
+    }
+
+    expect(openaiCompatibleErrorDataSchema.safeParse(data1).success).toBe(true)
+    expect(openaiCompatibleErrorDataSchema.safeParse(data2).success).toBe(true)
+    expect(openaiCompatibleErrorDataSchema.safeParse(data3).success).toBe(true)
+  })
+})
+
+describe("defaultOpenAICompatibleErrorStructure.errorToMessage", () => {
+  test("extracts message from standard error format", () => {
+    const data: OpenAICompatibleErrorData = {
+      error: {
+        message: "Invalid input",
+        type: "invalid_request_error",
+        param: null,
+        code: null,
+      },
+    }
+
+    const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(data)
+    expect(msg).toBe("Invalid input")
+  })
+
+  test("extracts message from status_code-wrapped format", () => {
+    const data: OpenAICompatibleErrorData = {
+      status_code: 500,
+      error: {
+        message: "Internal server error",
+        type: "server_error",
+        param: "",
+        code: "",
+        id: "err-123",
+      },
+    } as OpenAICompatibleErrorData
+
+    const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(data)
+    expect(msg).toBe("Internal server error")
+  })
+
+  test("handles empty message string", () => {
+    const data: OpenAICompatibleErrorData = {
+      error: {
+        message: "",
+        type: null,
+        param: null,
+        code: null,
+      },
+    }
+
+    const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(data)
+    expect(msg).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes `AI_TypeValidationError` (`invalid_union`) when OpenAI-compatible providers return HTTP 5xx responses with a `status_code`-wrapped error body that the previous schema could not parse.

### Root cause
`openaiCompatibleErrorDataSchema` only accepted standard OpenAI error format:
```json
{"error": {"message": "...", "type": "...", "param": "...", "code": "..."}}
```

Some providers return a wrapped variant:
```json
{"status_code": 500, "error": {"message": "...", "type": "server_error", "param": "", "code": "", "id": ""}}
```

The `AI_TypeValidationError` was thrown inside `postJsonToApi()` during `failedResponseHandler` Zod validation — before any user-level code could handle it. The fix in #365 (`choices` guard) was unreachable in this error path.

### Fix
- Split schema into `standardErrorObject` (with `.strict()` on outer object) and `wrappedErrorObject`
- Export as `z.union([standardErrorObject, wrappedErrorObject])`
- `.strict()` on `standardErrorObject` ensures payloads with `status_code` at root correctly route to `wrappedErrorObject` (prevents union short-circuit bug)
- `.passthrough()` on inner `error` objects allows unknown provider-specific fields
- `errorToMessage` works cleanly on both union branches via TypeScript type inference

### Tests
New test file `packages/opencode/test/provider/copilot/openai-compatible-error.test.ts` with 15 tests covering both formats, edge cases, and `errorToMessage` extraction.

Fixes #367