### PR TITLE
fix(provider): bypass @ai-sdk/cerebras to fix AI_TypeValidationError on status_code-wrapped errors

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -527,6 +527,32 @@
            "standardErrorObject"
          ]
         }
+      },
+      "cerebras-error-normalization": {
+       "status": "active",
+       "description": "Overrides @ai-sdk/cerebras in the cerebras custom loader to use OpenAICompatibleChatLanguageModel with defaultOpenAICompatibleErrorStructure, so Cerebras status_code-wrapped error responses are handled correctly instead of throwing AI_TypeValidationError.",
+       "issue": "https://github.com/randomm/opencode/issues/369",
+       "newFiles": [],
+       "modifiedFiles": [
+         "packages/opencode/src/provider/provider.ts"
+       ],
+"criticalCode": [
+          "OpenAICompatibleChatLanguageModel",
+          "defaultOpenAICompatibleErrorStructure",
+          "X-Cerebras-3rd-Party-Integration",
+          "api.cerebras.ai",
+          "CEREBRAS_API_KEY"
+        ],
+       "tests": [
+         "packages/opencode/test/provider/cerebras-error-schema.test.ts"
+       ],
+       "upstreamTracking": {
+         "absorptionSignals": [
+           "cerebras.*OpenAICompatibleChatLanguageModel",
+           "cerebras.*errorStructure",
+           "cerebras.*defaultOpenAICompatibleErrorStructure"
+         ]
+        }
       }
    }
  }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -571,10 +571,26 @@ export namespace Provider {
     cerebras: async () => {
       return {
         autoload: false,
+        async getModel(_sdk: any, modelID: string, _options?: Record<string, any>) {
+          const { OpenAICompatibleChatLanguageModel } = await import(
+            "./sdk/copilot/chat/openai-compatible-chat-language-model"
+          )
+          const { defaultOpenAICompatibleErrorStructure } = await import(
+            "./sdk/copilot/openai-compatible-error"
+          )
+
+          return new OpenAICompatibleChatLanguageModel(modelID, {
+            provider: "cerebras",
+            headers: () => ({
+              "X-Cerebras-3rd-Party-Integration": "opencode",
+              Authorization: `Bearer ${Env.get("CEREBRAS_API_KEY") ?? ""}`,
+            }),
+            url: ({ path }) => `https://api.cerebras.ai/v1${path}`,
+            errorStructure: defaultOpenAICompatibleErrorStructure,
+          })
+        },
         options: {
-          headers: {
-            "X-Cerebras-3rd-Party-Integration": "opencode",
-          },
+          apiKey: "",
         },
       }
     },

--- a/packages/opencode/test/provider/cerebras-error-schema.test.ts
+++ b/packages/opencode/test/provider/cerebras-error-schema.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from "bun:test"
+import {
+  openaiCompatibleErrorDataSchema,
+  defaultOpenAICompatibleErrorStructure,
+  type OpenAICompatibleErrorData,
+} from "../../src/provider/sdk/copilot/openai-compatible-error"
+
+describe("Cerebras Error Schema Integration", () => {
+  test("cerebras custom loader uses defaultOpenAICompatibleErrorStructure", () => {
+    // Verify that the error schema accepts standard format
+    const standardError = {
+      error: {
+        message: "Invalid request",
+        type: "invalid_request_error",
+        param: "messages",
+        code: "invalid_input",
+      },
+    }
+
+    const standardResult = openaiCompatibleErrorDataSchema.safeParse(standardError)
+    expect(standardResult.success).toBe(true)
+    if (standardResult.success) {
+      const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(standardResult.data)
+      expect(msg).toBe("Invalid request")
+    }
+  })
+
+  test("cerebras custom loader handles status_code-wrapped error responses", () => {
+    // Verify that cerebras responses like {status_code:500, error:{message:"..."}} are accepted
+    const wrappedError = {
+      status_code: 500,
+      error: {
+        message: "Internal server error",
+        type: "server_error",
+        param: "",
+        code: "500",
+        id: "err-123",
+      },
+    }
+
+    const wrappedResult = openaiCompatibleErrorDataSchema.safeParse(wrappedError)
+    expect(wrappedResult.success).toBe(true)
+    if (wrappedResult.success) {
+      const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(wrappedResult.data)
+      expect(msg).toBe("Internal server error")
+    }
+  })
+
+  test("cerebras errorToMessage extracts message from standard format", () => {
+    const standard = {
+      error: {
+        message: "Invalid input",
+        type: "invalid_request_error",
+        param: null,
+        code: null,
+      },
+    } satisfies OpenAICompatibleErrorData
+
+    const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(standard)
+    expect(msg).toBe("Invalid input")
+  })
+
+  test("cerebras errorToMessage extracts message from wrapped format", () => {
+    const wrapped = {
+      status_code: 500,
+      error: {
+        message: "Server error",
+        type: "server_error",
+        param: "",
+        code: "500",
+        id: "req-456",
+      },
+    } as OpenAICompatibleErrorData
+
+    const msg = defaultOpenAICompatibleErrorStructure.errorToMessage(wrapped)
+    expect(msg).toBe("Server error")
+  })
+
+  test("cerebras schemas allow extra fields in both formats", () => {
+    // Standard format with extra fields
+    const standardExtra = {
+      error: {
+        message: "Error",
+        type: "error",
+        param: null,
+        code: null,
+        request_id: "req-123",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    }
+
+    expect(
+      openaiCompatibleErrorDataSchema.safeParse(standardExtra).success,
+    ).toBe(true)
+
+    // Wrapped format with extra fields
+    const wrappedExtra = {
+      status_code: 500,
+      error: {
+        message: "Error",
+        type: "server_error",
+        param: "",
+        code: "500",
+        id: "err-123",
+        trace_id: "trace-456",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    }
+
+    expect(
+      openaiCompatibleErrorDataSchema.safeParse(wrappedExtra).success,
+    ).toBe(true)
+  })
+})

--- a/packages/opencode/test/provider/cerebras-error-schema.test.ts
+++ b/packages/opencode/test/provider/cerebras-error-schema.test.ts
@@ -3,7 +3,7 @@ import {
   openaiCompatibleErrorDataSchema,
   defaultOpenAICompatibleErrorStructure,
   type OpenAICompatibleErrorData,
-} from "../../src/provider/sdk/copilot/openai-compatible-error"
+} from "@/provider/sdk/copilot/openai-compatible-error"
 
 describe("Cerebras Error Schema Integration", () => {
   test("cerebras custom loader uses defaultOpenAICompatibleErrorStructure", () => {

--- a/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
@@ -3,7 +3,7 @@ import {
   openaiCompatibleErrorDataSchema,
   defaultOpenAICompatibleErrorStructure,
   type OpenAICompatibleErrorData,
-} from "@/provider/sdk/copilot/openai-compatible-error"
+} from "../../../src/provider/sdk/copilot/openai-compatible-error"
 import { z } from "zod/v4"
 
 describe("openaiCompatibleErrorDataSchema", () => {

--- a/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
+++ b/packages/opencode/test/provider/copilot/openai-compatible-error.test.ts
@@ -3,7 +3,7 @@ import {
   openaiCompatibleErrorDataSchema,
   defaultOpenAICompatibleErrorStructure,
   type OpenAICompatibleErrorData,
-} from "../../../src/provider/sdk/copilot/openai-compatible-error"
+} from "@/provider/sdk/copilot/openai-compatible-error"
 import { z } from "zod/v4"
 
 describe("openaiCompatibleErrorDataSchema", () => {


### PR DESCRIPTION
## Summary

Fixes intermittent `AI_TypeValidationError` for `cerebras/zai-glm-4.7` (and other Cerebras models) on transient server errors.

### Root cause
`cerebras/zai-glm-4.7` routes through the external `@ai-sdk/cerebras` npm package, which has its own error schema that cannot handle Cerebras' actual error format:
```json
{"status_code": 500, "error": {"message": "...", "type": "server_error", ...}}
```
Previous fixes (#366, #368) only patched our in-house `OpenAICompatibleChatLanguageModel` — not the external package.

### Fix
Override the cerebras custom loader in `provider.ts` with a `getModel` handler that instantiates `OpenAICompatibleChatLanguageModel` directly, bypassing `@ai-sdk/cerebras` entirely. Key changes:
- Uses `defaultOpenAICompatibleErrorStructure` (from PR #368) which accepts both standard `{error:{...}}` and wrapped `{status_code, error:{...}}` formats
- Points at `https://api.cerebras.ai/v1` directly
- Keeps `X-Cerebras-3rd-Party-Integration: opencode` header
- Reads auth via `Env.get("CEREBRAS_API_KEY")`

### Tests
New test file `packages/opencode/test/provider/cerebras-error-schema.test.ts` validates the error schema contract for the Cerebras path.

Fixes #369