### PR TITLE
fix(fork-features): mark remove-hashline as dropped in manifest

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -264,7 +264,8 @@
       }
     },
     "remove-hashline": {
-      "status": "active",
+      "status": "dropped",
+      "droppedReason": "Feature removed in issue #360 — zero agent adoption and test failures after 25-day experiment. Pure fork invention (upstream never had hashline), no re-introduction risk. All 8 source/test files deleted (1,921 lines).",
       "description": "Removed hashline_read and hashline_edit experimental tools entirely. They were off-by-default, used by zero agents, and causing test failures. Deleted 5 source files and 3 test files. Cleaned up OPENCODE_EXPERIMENTAL_HASHLINE flag from flag.ts, hashlineRead state/functions from file/time.ts, and all imports/registrations from tool/registry.ts. The edit tool now always registers (no hashline condition).",
       "issue": "https://github.com/randomm/opencode/issues/360",
       "newFiles": [],


### PR DESCRIPTION
The `remove-hashline` entry in `.fork-features/manifest.json` had `"status": "active"` despite all hashline code being deleted in issue #360. This marks it as `"dropped"` with a reason, matching the pattern used by the existing `"1m-context"` entry.

**Changes:**
- `remove-hashline.status`: `"active"` → `"dropped"`
- Added `droppedReason` explaining when/why removed

**Verification:**
- `bun run typecheck` passes (0 errors)
- `verify.ts` correctly skips dropped entries (line 38 filters to `status === "active"`)
- JSON valid

Fixes #372