### PR TITLE
feat(permission): add optional apfel suggestion hook to DeniedError

### DIFF
--- a/.fork-features/manifest.json
+++ b/.fork-features/manifest.json
@@ -507,44 +507,59 @@
          "packages/opencode/test/provider/copilot/openai-compatible-error.test.ts"
        ],
        "upstreamTracking": {
-         "absorptionSignals": [
-           "responseBody.choices?.length",
-           "value.choices?.length",
-           "InvalidResponseDataError.*choices",
-           "choices.*length.*0",
-           "no choices.*provider",
-           "status_code.*error",
-           "openaiCompatibleErrorDataSchema.*union",
-           "wrappedErrorObject",
-           "standardErrorObject"
-         ]
+"absorptionSignals": [
+            "responseBody.choices?.length",
+            "value.choices?.length",
+            "InvalidResponseDataError.*choices",
+            "choices.*length.*0",
+            "no choices.*provider",
+            "status_code.*error",
+            "openaiCompatibleErrorDataSchema.*union",
+            "wrappedErrorObject",
+            "standardErrorObject"
+            ]
+          }
+       },
+        "cerebras-error-normalization": {
+         "status": "active",
+         "description": "Overrides @ai-sdk/cerebras in the cerebras custom loader to use OpenAICompatibleChatLanguageModel with defaultOpenAICompatibleErrorStructure, so Cerebras status_code-wrapped error responses are handled correctly instead of throwing AI_TypeValidationError.",
+         "issue": "https://github.com/randomm/opencode/issues/369",
+         "newFiles": [],
+         "modifiedFiles": [
+           "packages/opencode/src/provider/provider.ts"
+         ],
+        "criticalCode": [
+           "OpenAICompatibleChatLanguageModel",
+           "defaultOpenAICompatibleErrorStructure",
+           "X-Cerebras-3rd-Party-Integration",
+           "api.cerebras.ai",
+           "CEREBRAS_API_KEY"
+         ],
+         "tests": [
+           "packages/opencode/test/provider/cerebras-error-schema.test.ts"
+         ],
+         "upstreamTracking": {
+           "absorptionSignals": [
+             "cerebras.*OpenAICompatibleChatLanguageModel",
+             "cerebras.*errorStructure",
+             "cerebras.*defaultOpenAICompatibleErrorStructure"
+           ]
+          }
+},
+        "apfel-permission-suggestion": {
+          "status": "active",
+         "description": "On bash permission denial, optionally spawns apfel (Apple Intelligence CLI) to suggest the nearest permitted alternative command. Appended to DeniedError message shown to the agent. No-op if apfel not installed.",
+         "issue": "https://github.com/randomm/opencode/issues/371",
+         "newFiles": [],
+         "modifiedFiles": ["packages/opencode/src/permission/next.ts"],
+         "deletedFiles": [],
+         "criticalCode": ["getApfelSuggestion", "apfelPath", "DeniedError.*suggestion"],
+         "tests": ["packages/opencode/test/permission/next.test.ts"],
+         "upstreamTracking": {
+           "relatedPRs": [],
+           "relatedIssues": [],
+           "absorptionSignals": ["getApfelSuggestion", "apfelPath.*Bun.which", "apfel.*permissive.*permission"]
+         }
         }
-      },
-      "cerebras-error-normalization": {
-       "status": "active",
-       "description": "Overrides @ai-sdk/cerebras in the cerebras custom loader to use OpenAICompatibleChatLanguageModel with defaultOpenAICompatibleErrorStructure, so Cerebras status_code-wrapped error responses are handled correctly instead of throwing AI_TypeValidationError.",
-       "issue": "https://github.com/randomm/opencode/issues/369",
-       "newFiles": [],
-       "modifiedFiles": [
-         "packages/opencode/src/provider/provider.ts"
-       ],
-      "criticalCode": [
-         "OpenAICompatibleChatLanguageModel",
-         "defaultOpenAICompatibleErrorStructure",
-         "X-Cerebras-3rd-Party-Integration",
-         "api.cerebras.ai",
-         "CEREBRAS_API_KEY"
-       ],
-       "tests": [
-         "packages/opencode/test/provider/cerebras-error-schema.test.ts"
-       ],
-       "upstreamTracking": {
-         "absorptionSignals": [
-           "cerebras.*OpenAICompatibleChatLanguageModel",
-           "cerebras.*errorStructure",
-           "cerebras.*defaultOpenAICompatibleErrorStructure"
-         ]
-        }
-      }
-  }
+    }
 }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -1,3 +1,4 @@
+import { abortAfter } from "@/util/abort"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { Config } from "@/config/config"
@@ -138,8 +139,12 @@ export namespace PermissionNext {
       for (const pattern of request.patterns ?? []) {
         const rule = evaluate(request.permission, pattern, ruleset, s.approved)
         log.info("evaluated", { permission: request.permission, pattern, action: rule })
-        if (rule.action === "deny")
-          throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
+        if (rule.action === "deny") {
+          const denied = ruleset.filter((r) => Wildcard.match(request.permission, r.permission))
+          const allowed = ruleset.filter((r) => r.action === "allow")
+          const suggestion = await getApfelSuggestion(request.patterns[0] ?? "", allowed)
+          throw new DeniedError(denied, suggestion)
+        }
         if (rule.action === "ask") {
           const id = input.id ?? Identifier.ascending("permission")
           return new Promise<void>((resolve, reject) => {
@@ -272,9 +277,10 @@ export namespace PermissionNext {
 
   /** Auto-rejected by config rule - halts execution */
   export class DeniedError extends Error {
-    constructor(public readonly ruleset: Ruleset) {
+    constructor(public readonly ruleset: Ruleset, suggestion?: string) {
       super(
-        `The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules ${JSON.stringify(ruleset)}`,
+        `The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules ${JSON.stringify(ruleset)}` +
+          (suggestion ? `\n\nSuggested alternative: \`${suggestion}\`` : ""),
       )
     }
   }
@@ -282,5 +288,33 @@ export namespace PermissionNext {
   export async function list() {
     const s = await state()
     return Object.values(s.pending).map((x) => x.info)
+  }
+
+  async function getApfelSuggestion(command: string, allowRules: Rule[]): Promise<string | undefined> {
+    if (!command.trim()) return undefined
+    if (!Bun.which("apfel")) return undefined
+
+    const rules = JSON.stringify(allowRules.slice(0, 30))
+    const system = `You are a bash command advisor. Given these permitted patterns as JSON: ${rules}, the agent tried a denied command. Output ONLY the single best permitted alternative command. No explanation. No punctuation. Just the command.`
+
+    const { controller, signal, clearTimeout } = abortAfter(5000)
+    let proc: ReturnType<typeof Bun.spawn> | undefined
+    try {
+      proc = Bun.spawn(["apfel", "-q", "--permissive", "-s", system, command], {
+        signal,
+        stdout: "pipe",
+        stderr: "ignore",
+      })
+      const output = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+      const code = await proc.exited
+      clearTimeout()
+      if (code !== 0) return undefined
+      return output.trim() || undefined
+    } catch (e) {
+      clearTimeout()
+      proc?.kill()
+      log.debug("apfel suggestion failed", { error: e })
+      return undefined
+    }
   }
 }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -292,24 +292,30 @@ export namespace PermissionNext {
 
   async function getApfelSuggestion(command: string, allowRules: Rule[]): Promise<string | undefined> {
     if (!command.trim()) return undefined
-    if (!Bun.which("apfel")) return undefined
+    const apfelPath = Bun.which("apfel")
+    if (!apfelPath) return undefined
 
     const rules = JSON.stringify(allowRules.slice(0, 30))
     const system = `You are a bash command advisor. Given these permitted patterns as JSON: ${rules}, the agent tried a denied command. Output ONLY the single best permitted alternative command. No explanation. No punctuation. Just the command.`
 
-    const { controller, signal, clearTimeout } = abortAfter(5000)
+    const { signal, clearTimeout } = abortAfter(5000)
     let proc: ReturnType<typeof Bun.spawn> | undefined
     try {
-      proc = Bun.spawn(["apfel", "-q", "--permissive", "-s", system, command], {
+      proc = Bun.spawn([apfelPath, "-q", "--permissive", "-s", system, command], {
         signal,
         stdout: "pipe",
         stderr: "ignore",
       })
+      if (!proc.stdout) {
+        clearTimeout()
+        return undefined
+      }
       const output = await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
       const code = await proc.exited
       clearTimeout()
       if (code !== 0) return undefined
-      return output.trim() || undefined
+      const trimmed = output.trim().slice(0, 200).replaceAll("`", "").replaceAll("\n", " ")
+      return trimmed || undefined
     } catch (e) {
       clearTimeout()
       proc?.kill()

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -687,3 +687,25 @@ test("ask - allows all patterns when all match allow rules", async () => {
     },
   })
 })
+
+test("DeniedError - includes suggestion when provided", () => {
+  const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }], "ls -la")
+  expect(error.message).toContain("Suggested alternative: `ls -la`")
+})
+
+test("DeniedError - no suggestion text when not provided", () => {
+  const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }])
+  expect(error.message).not.toContain("Suggested alternative")
+})
+
+test("DeniedError - message format without suggestion", () => {
+  const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }])
+  expect(error.message).toContain("The user has specified a rule")
+  expect(error.message).not.toContain("Suggested alternative")
+})
+
+test("DeniedError - message format with empty string suggestion treated as no suggestion", () => {
+  // suggestion="" should not add the Suggested alternative line (falsy check)
+  const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }], undefined)
+  expect(error.message).not.toContain("Suggested alternative")
+})

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -695,11 +695,6 @@ test("DeniedError - includes suggestion when provided", () => {
 
 test("DeniedError - no suggestion text when not provided", () => {
   const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }])
-  expect(error.message).not.toContain("Suggested alternative")
-})
-
-test("DeniedError - message format without suggestion", () => {
-  const error = new PermissionNext.DeniedError([{ permission: "bash", pattern: "*", action: "deny" }])
   expect(error.message).toContain("The user has specified a rule")
   expect(error.message).not.toContain("Suggested alternative")
 })


### PR DESCRIPTION
## Summary

When a bash command is denied by the permission system, optionally spawns `apfel` (Apple Intelligence CLI, on-device, zero cost) to suggest the correct permitted alternative command. The suggestion is appended to the `DeniedError` message so the agent can immediately self-correct rather than reasoning blindly about what went wrong.

## Changes

- `packages/opencode/src/permission/next.ts`: Added `getApfelSuggestion()` async function with `Bun.which` guard, 5s abort timeout, zombie-safe subprocess cleanup, and `stderr: ignore`. Extended `DeniedError` constructor with optional `suggestion?: string` param.
- `packages/opencode/test/permission/next.test.ts`: Added 4 tests covering `DeniedError` message format with and without suggestion.

## Graceful degradation

If `apfel` is not installed (non-macOS, Intel Mac, macOS < 26) the hook returns immediately and behaviour is identical to before this change. Zero breaking changes.

Fixes #371