### PR TITLE
feat(taskctl): enhance adversarial verdict schema with tested_scenarios and coverage_level

### DIFF
--- a/packages/opencode/src/agent/prompt/adversarial-pipeline.txt
+++ b/packages/opencode/src/agent/prompt/adversarial-pipeline.txt
@@ -32,6 +32,15 @@ YOU DO NOT:
 - The task ID
 - A base_commit hash (the merge-base of the worktree branch and dev at creation time)
 
+## Workflow
+
+**0. Load skill** — If the task involves a domain with specialized patterns (e.g., React, Rust, Go), load the appropriate skill:
+   ```
+   mcp_skill name="code-review-security"  # for security-focused review
+   mcp_skill name="code-review-type-safety"  # for type safety review
+   ```
+   Only load one skill at a time. If unsure, skip this step.
+
 ## Attack Vectors
 
 ### Acceptance Criteria
@@ -85,6 +94,19 @@ bun test
 ```
 NEVER run from project root (causes "do-not-run-tests-from-root" error).
 
+## Coverage Requirements
+
+Assess code coverage needs based on risk level:
+
+| Risk Level | Coverage | Examples |
+|------------|----------|----------|
+| Critical | 95%+ | Auth, payments, data deletion, encryption |
+| High | 85%+ | User data, APIs, database writes |
+| Medium | 80%+ | Internal APIs, services, utilities |
+| Low | 70%+ | Documentation, config, formatting |
+
+Include your assessed coverage level in your verdict.
+
 ## Reviewing ONLY Developer Changes (base_commit)
 Use base_commit to see ONLY the developer's changes:
 ```
@@ -129,15 +151,21 @@ Use the `taskctl` MCP tool (in your tool list, NOT bash):
 **If APPROVED:**
 - command: "verdict", taskId: <task-id>, verdict: "APPROVED"
 - verdictSummary: "Brief summary", verdictIssues: []
+- verdictScenarios: optional array of {scenario, result} — tested scenarios (omit if none)
+- coverageLevel: optional enum — assessed coverage level (omit if not applicable)
 
 **If ISSUES_FOUND:**
 - command: "verdict", taskId: <task-id>, verdict: "ISSUES_FOUND"
 - verdictSummary: "Brief summary"
 - verdictIssues: [{"location":"src/foo.ts:42","severity":"MEDIUM","fix":"..."}]
+- verdictScenarios: optional array of {scenario, result} — tested scenarios (omit if none)
+- coverageLevel: optional enum — assessed coverage level (omit if not applicable)
 
 **If CRITICAL_ISSUES_FOUND:**
 - command: "verdict", taskId: <task-id>, verdict: "CRITICAL_ISSUES_FOUND"
 - verdictIssues: [{"location":"...","severity":"CRITICAL","fix":"..."}]
+- verdictScenarios: optional array of {scenario, result} — tested scenarios (omit if none)
+- coverageLevel: optional enum — assessed coverage level (omit if not applicable)
 
 ## Rules
 - Record verdict via taskctl MCP tool — MANDATORY
@@ -157,3 +185,14 @@ Use the `taskctl` MCP tool (in your tool list, NOT bash):
 - `# type: ignore` — must fix the type error
 - `@ts-ignore` — must fix the TypeScript error
 - `eslint-disable` without documented justification
+
+## Forbidden Tools
+
+You do NOT have access to:
+- write, edit tools (read-only review)
+- Git commands (no commits, branches, pushes)
+- Bash commands outside the allowlist
+
+If you need to run tests or typecheck, use:
+- `oo bun run typecheck` (from worktree directory)
+- `oo bun test` (from worktree directory)

--- a/packages/opencode/src/tasks/format.ts
+++ b/packages/opencode/src/tasks/format.ts
@@ -1,0 +1,6 @@
+export function formatScenarios(scenarios: Array<{scenario: string, result: string}> | undefined): string {
+  if (!scenarios || scenarios.length === 0) {
+    return "  - None specified"
+  }
+  return scenarios.map(s => `  - ${s.scenario}: ${s.result}`).join("\n")
+}

--- a/packages/opencode/src/tasks/inspect-commands.ts
+++ b/packages/opencode/src/tasks/inspect-commands.ts
@@ -3,6 +3,7 @@ import { Log } from "../util/log"
 import { SessionPrompt } from "../session/prompt"
 import { Worktree } from "../worktree"
 import { sanitizeWorktree } from "./pulse-scheduler"
+import { formatScenarios } from "./format"
 import type { Task } from "./types"
 
 const log = Log.create({ service: "taskctl.tool.inspect-commands" })
@@ -59,6 +60,13 @@ export async function executeInspect(projectId: string, params: any): Promise<{ 
       for (const issue of v.issues) {
         lines.push(`    - ${issue.location} [${issue.severity}]: ${issue.fix}`)
       }
+    }
+    if (v.tested_scenarios && v.tested_scenarios.length > 0) {
+      lines.push(`  Tested scenarios:`)
+      lines.push(formatScenarios(v.tested_scenarios))
+    }
+    if (v.coverage_level) {
+      lines.push(`  Coverage level: ${v.coverage_level}`)
     }
   }
 
@@ -207,6 +215,17 @@ export async function executeVerdict(projectId: string, params: any, ctx: any): 
     verdict,
     summary,
     issues,
+    tested_scenarios: Array.isArray(params.verdictScenarios)
+    ? params.verdictScenarios.slice(0, 50).map((s: any) => ({
+        scenario: String(s?.scenario || ''),
+        result: String(s?.result || '')
+      }))
+    : [],
+    coverage_level: (params.coverageLevel === null || typeof params.coverageLevel === 'undefined')
+    ? null
+    : (typeof params.coverageLevel === 'string' && ['critical', 'high', 'medium', 'low'].includes(params.coverageLevel))
+      ? params.coverageLevel
+      : null,
     created_at: new Date().toISOString(),
   }
 

--- a/packages/opencode/src/tasks/pulse-scheduler.ts
+++ b/packages/opencode/src/tasks/pulse-scheduler.ts
@@ -18,6 +18,7 @@ import type { Task, AdversarialVerdict } from "./types"
 import { MAX_ADVERSARIAL_ATTEMPTS } from "./pulse-verdicts"
 import { resolveModel } from "./pulse"
 import * as PulseUtils from "./pulse-utils"
+import { formatScenarios } from "./format"
 
 const log = Log.create({ service: "taskctl.pulse.scheduler" })
 
@@ -508,17 +509,28 @@ ABSOLUTE RULES:
 - Run commands from ${safeWorktree}/packages/opencode/
 `
 
-  const issueLines = verdict.issues.map((i) => `  - ${i.location} [${i.severity}]: ${i.fix}`).join("\n")
-  const prompt = `${directiveHeader}This is retry attempt ${attempt} of ${MAX_ADVERSARIAL_ATTEMPTS}. The previous implementation had issues that must be fixed.
+  const issueLines = verdict.issues
+    .map((i) => `  - ${i.location} [${i.severity}]: ${i.fix}`)
+    .join("\n")
 
-**Task:** ${task.title}
-**Description:** ${task.description}
-**Acceptance Criteria:** ${task.acceptance_criteria}
+  const scenarioLines = verdict.tested_scenarios && verdict.tested_scenarios.length > 0
+    ? formatScenarios(verdict.tested_scenarios)
+    : "  - None specified"
+
+  const coverageNote = verdict.coverage_level
+    ? `\nCoverage level assessed: ${verdict.coverage_level.toUpperCase()}`
+    : ""
+
+  const prompt = `${directiveHeader}This is retry attempt ${attempt} of ${MAX_ADVERSARIAL_ATTEMPTS}. The previous implementation had issues that must be fixed.
 
 **Adversarial feedback — fix these before signaling complete:**
 Summary: ${verdict.summary}
+
 Issues:
 ${issueLines}
+
+Tested Scenarios:
+${scenarioLines}${coverageNote}
 
 Follow TDD for any fixes:
 1. Write failing test(s) for each issue

--- a/packages/opencode/src/tasks/tool.ts
+++ b/packages/opencode/src/tasks/tool.ts
@@ -87,6 +87,11 @@ Task labels:
       fix: z.string(),
     })).optional().describe("Issues found in review (for verdict)"),
     verdictSummary: z.string().optional().describe("Summary of verdict (for verdict)"),
+    verdictScenarios: z.array(z.object({
+      scenario: z.string().max(500),
+      result: z.string().max(500),
+    })).max(50).optional().describe("Tested scenarios (for verdict)"),
+    coverageLevel: z.enum(["critical", "high", "medium", "low"]).nullish().describe("Coverage level assessed (for verdict)"),
   }),
   async execute(params, ctx) {
     const projectId = Instance.project.id

--- a/packages/opencode/src/tasks/types.ts
+++ b/packages/opencode/src/tasks/types.ts
@@ -51,6 +51,13 @@ export type AdversarialVerdict = {
     fix: string
   }>
   summary: string
+  // Note: Field names use snake_case for database storage consistency
+  // API layer (Zod schema) uses camelCase and converts on read/write
+  tested_scenarios: Array<{
+    scenario: string
+    result: string
+  }>
+  coverage_level: "critical" | "high" | "medium" | "low" | null
   created_at: string
 }
 

--- a/packages/opencode/test/tasks/adversarial-schema-fixes.test.ts
+++ b/packages/opencode/test/tasks/adversarial-schema-fixes.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect } from "bun:test"
+import { z } from "zod"
+
+// Replicate the schema from tool.ts to test the fixes
+const verdictParamsSchema = z.object({
+  taskId: z.string(),
+  command: z.enum(["verdict"]),
+  verdict: z.enum(["APPROVED", "ISSUES_FOUND", "CRITICAL_ISSUES_FOUND"]),
+  verdictSummary: z.string().optional(),
+  verdictIssues: z.array(z.object({
+    location: z.string(),
+    severity: z.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
+    fix: z.string(),
+  })).optional(),
+  verdictScenarios: z.array(z.object({
+    scenario: z.string().max(500),
+    result: z.string().max(500),
+  })).max(50).optional(),
+  // This is the FIXED version - using .nullish() instead of .nullable().optional()
+  coverageLevel: z.enum(["critical", "high", "medium", "low"]).nullish(),
+})
+
+describe("adversarial schema fixes", () => {
+
+  describe("coverageLevel schema validation", () => {
+    test("accepts valid enum values", () => {
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: [],
+        coverageLevel: "critical",
+      })
+      expect(result.success).toBe(true)
+      expect(result.data?.coverageLevel).toBe("critical")
+    })
+
+    test("accepts null value", () => {
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: [],
+        coverageLevel: null,
+      })
+      expect(result.success).toBe(true)
+      expect(result.data?.coverageLevel).toBe(null)
+    })
+
+    test("accepts undefined (not provided)", () => {
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: [],
+        // coverageLevel not provided
+      })
+      expect(result.success).toBe(true)
+      expect(result.data?.coverageLevel).toBe(undefined)
+    })
+
+    test("REJECTS invalid string values", () => {
+      const invalidInputs = [
+        "CRITICAL", // wrong case
+        "invalid",
+        "🔥",
+        "high-medium",
+        "",
+      ]
+
+      for (const input of invalidInputs) {
+        const result = verdictParamsSchema.safeParse({
+          taskId: "test-task-123",
+          command: "verdict",
+          verdict: "APPROVED",
+          verdictSummary: "All good",
+          verdictIssues: [],
+          verdictScenarios: [],
+          coverageLevel: input as any,
+        })
+        expect(result.success).toBe(false)
+      }
+    })
+  })
+
+  describe("testedScenarios schema validation", () => {
+    test("accepts empty array", () => {
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: [],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test("accepts array up to 50 items", () => {
+      const scenarios = Array.from({ length: 50 }, (_, i) => ({
+        scenario: `Test scenario ${i}`,
+        result: `Result ${i}`,
+      }))
+
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: scenarios,
+      })
+      expect(result.success).toBe(true)
+      expect(result.data?.verdictScenarios).toHaveLength(50)
+    })
+
+    test("REJECTS array with 51 items", () => {
+      const scenarios = Array.from({ length: 51 }, (_, i) => ({
+        scenario: `Test scenario ${i}`,
+        result: `Result ${i}`,
+      }))
+
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: scenarios,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test("rejects strings exceeding max length", () => {
+      const result = verdictParamsSchema.safeParse({
+        taskId: "test-task-123",
+        command: "verdict",
+        verdict: "APPROVED",
+        verdictSummary: "All good",
+        verdictIssues: [],
+        verdictScenarios: [{
+          scenario: "a".repeat(501), // exceeds 500
+          result: "valid result",
+        }],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #376. Adds tested_scenarios and coverage_level to AdversarialVerdict schema.