### PR TITLE
fix(taskctl): detect repo from git remote instead of hardcoding

### DIFF
--- a/packages/opencode/src/tasks/job-commands.ts
+++ b/packages/opencode/src/tasks/job-commands.ts
@@ -9,6 +9,7 @@ import { SessionPrompt } from "../session/prompt"
 import { Worktree } from "../worktree"
 import { Instance } from "../project/instance"
 import * as PulseUtils from "./pulse-utils"
+import { getGithubRepo } from "../util/git"
 
 const log = Log.create({ service: "taskctl.tool.job-commands" })
 
@@ -117,7 +118,7 @@ export async function executeStart(projectId: string, params: any, ctx: any): Pr
 
   enableAutoWakeup(ctx.sessionID)
 
-  const repo = "randomm/opencode"
+  const repo = await getGithubRepo(cwd) ?? "randomm/opencode"
 
   let issueOutput: { title: string; body: string } | null = null
   const proc = Bun.spawn(["gh", "issue", "view", issueNumber.toString(), "--repo", repo, "--json", "title,body"], {

--- a/packages/opencode/src/tasks/pulse-verdicts.ts
+++ b/packages/opencode/src/tasks/pulse-verdicts.ts
@@ -15,6 +15,7 @@ import type { Task, AdversarialVerdict } from "./types"
 import { scheduleReadyTasks } from "./pulse-scheduler"
 import { sanitizeWorktree } from "./pulse-scheduler"
 import { isSessionActivelyRunning, lockFilePath } from "./pulse-scheduler"
+import { getGithubRepo } from "../util/git"
 
 // Allow 6 attempts to resolve minor test flakiness before escalating to PM
 const MAX_ADVERSARIAL_ATTEMPTS = 6
@@ -444,7 +445,7 @@ async function createPRForJob(projectId: string, tasks: Task[], pmSessionId: str
       return { ok: false, error: `Feature branch ${safeFeatureBranch} has no commits ahead of dev` }
     }
 
-    const repo = "randomm/opencode"
+    const repo = await getGithubRepo(parentSession.directory) ?? "randomm/opencode"
     const prTitle = `Issue #${issueNumber}: Automated PR from taskctl`
     const prBody = `Closes #${issueNumber}
 

--- a/packages/opencode/src/util/git.ts
+++ b/packages/opencode/src/util/git.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun"
+import { existsSync } from "node:fs"
 import { Flag } from "../flag/flag"
 
 export interface GitResult {
@@ -17,6 +18,16 @@ export interface GitResult {
  * case we fall back to `Bun.spawn` with `stdin: "ignore"`.
  */
 export async function git(args: string[], opts: { cwd: string; env?: Record<string, string> }): Promise<GitResult> {
+  // Check if directory exists before running git
+  if (!existsSync(opts.cwd)) {
+    return {
+      exitCode: 1,
+      text: () => "",
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+    }
+  }
+
   if (Flag.OPENCODE_CLIENT === "acp") {
     try {
       const proc = Bun.spawn(["git", ...args], {
@@ -52,7 +63,18 @@ export async function git(args: string[], opts: { cwd: string; env?: Record<stri
   }
 
   const env = opts.env ? { ...process.env, ...opts.env } : undefined
-  let cmd = $`git ${args}`.quiet().nothrow().cwd(opts.cwd)
+  let cmd = $`git ${args}`.quiet().nothrow()
+  // Handle non-existent directories - cwd() throws before command runs
+  try {
+    cmd = cmd.cwd(opts.cwd)
+  } catch {
+    return {
+      exitCode: 1,
+      text: () => "",
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+    }
+  }
   if (env) cmd = cmd.env(env)
   const result = await cmd
   return {
@@ -61,4 +83,42 @@ export async function git(args: string[], opts: { cwd: string; env?: Record<stri
     stdout: result.stdout,
     stderr: result.stderr,
   }
+}
+
+/**
+ * Get GitHub repository from git remote.
+ * Returns 'owner/repo' for GitHub URLs, null otherwise.
+ */
+export async function getGithubRepo(root: string): Promise<string | null> {
+  const result = await git(["remote", "get-url", "origin"], { cwd: root })
+  if (result.exitCode !== 0) return null
+
+  const url = await result.text()
+  const trimmedUrl = url.trim()
+
+  // Only parse GitHub URLs - validate actual domain to prevent spoofing
+  // SSH format: git@github.com:
+  // HTTPS format: https://github.com/ or http://github.com/
+  if (
+    !trimmedUrl.startsWith("git@github.com:") &&
+    !trimmedUrl.startsWith("https://github.com/") &&
+    !trimmedUrl.startsWith("http://github.com/") &&
+    !trimmedUrl.startsWith("ssh://git@github.com/")
+  ) {
+    return null
+  }
+
+  // Parse SSH: git@github.com:owner/repo.git
+  const sshMatch = trimmedUrl.match(/^git@github\.com:([^/]+)\/([^/]+?)(\.git)?$/)
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`
+
+  // Parse HTTPS: https://github.com/owner/repo.git or https://github.com/owner/repo
+  const httpsMatch = trimmedUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(\.git)?$/)
+  if (httpsMatch) return `${httpsMatch[1]}/${httpsMatch[2]}`
+
+  // Parse SSH with protocol: ssh://git@github.com/owner/repo.git
+  const sshProtocolMatch = trimmedUrl.match(/^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(\.git)?$/)
+  if (sshProtocolMatch) return `${sshProtocolMatch[1]}/${sshProtocolMatch[2]}`
+
+  return null
 }

--- a/packages/opencode/test/util/git.test.ts
+++ b/packages/opencode/test/util/git.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { getGithubRepo } from "../../src/util/git"
+import { mkdirSync, rmSync, existsSync } from "node:fs"
+import { $ } from "bun"
+
+describe("getGithubRepo", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = `/tmp/opencode-git-test-${Date.now()}`
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  test("parses SSH URL with .git suffix", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin git@github.com:owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("parses SSH URL without .git suffix", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin git@github.com:owner/repo`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("parses HTTPS URL with .git suffix", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin https://github.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("parses HTTPS URL without .git suffix", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin https://github.com/owner/repo`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("parses SSH URL with protocol", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin ssh://git@github.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("parses SSH URL with protocol without .git suffix", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin ssh://git@github.com/owner/repo`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("owner/repo")
+  })
+
+  test("returns null for GitLab URL", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin git@gitlab.com:owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for GitLab HTTPS URL", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin https://gitlab.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for Bitbucket URL", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin git@bitbucket.org:owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for Bitbucket HTTPS URL", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin https://bitbucket.org/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null when no remote configured", async () => {
+    await $`git init`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null for non-existent directory", async () => {
+    const result = await getGithubRepo("/non-existent-path")
+    expect(result).toBeNull()
+  })
+
+  test("handles owner and repo names with hyphens", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin git@github.com:my-org/my-repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("my-org/my-repo")
+  })
+
+  test("handles owner and repo names with numbers", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin https://github.com/org42/project123.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBe("org42/project123")
+  })
+
+  test("returns null for malformed URL", async () => {
+    await $`git init`.cwd(testDir)
+    await $`git remote add origin not-a-valid-url`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("rejects github.com.evil.com domain spoofing", async () => {
+    await $`git init`.cwd(testDir)
+    // This is a malicious URL that contains "github.com" but is not actually GitHub
+    await $`git remote add origin https://github.com.evil.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("rejects mygithub.com (substring in domain)", async () => {
+    await $`git init`.cwd(testDir)
+    // Substring in domain name - should be rejected
+    await $`git remote add origin https://mygithub.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+
+  test("rejects evil-github.com (substring with hyphen)", async () => {
+    await $`git init`.cwd(testDir)
+    // Substring with hyphen - should be rejected
+    await $`git remote add origin https://evil-github.com/owner/repo.git`.cwd(testDir)
+    const result = await getGithubRepo(testDir)
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #355

### Problem
`taskctl start <issueNumber>` hardcoded `"randomm/opencode"` as the repo, so running opencode in a different project would fetch issues from the wrong repo.

### Solution
- Created `getGithubRepo()` utility that detects repo from `git remote get-url origin`
- Parses both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) URLs
- Validates GitHub.com domain explicitly (rejects GitLab, Bitbucket, domain spoofing)
- Falls back to `"randomm/opencode"` if detection fails
- Uses existing `git()` helper for Windows ACP compatibility

### Files Changed
- `packages/opencode/src/util/git.ts` — New `getGithubRepo()` utility
- `packages/opencode/src/tasks/job-commands.ts` — Use `getGithubRepo()` in `executeStart`
- `packages/opencode/src/tasks/pulse-verdicts.ts` — Use `getGithubRepo()` in PR creation
- `packages/opencode/test/util/git.test.ts` — 18 comprehensive tests

### Testing
- 18 tests for all URL formats, edge cases, and security scenarios
- Domain spoofing attacks blocked (`github.com.evil.com`, `mygithub.com`, etc.)
- All existing tests pass